### PR TITLE
fix: 移除 agent_versions.tenant_id 外键约束

### DIFF
--- a/backend/migrations/versions/20260610_0048_drop_av_tenant_fk.py
+++ b/backend/migrations/versions/20260610_0048_drop_av_tenant_fk.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""drop agent_versions.tenant_id foreign key constraint.
+
+The agent_versions table was created with a FK on tenant_id -> tenants.id.
+However, platform-level agents use PLATFORM_TENANT_ID = 0 which has no
+matching row in the tenants table, causing IntegrityError on publish.
+
+This aligns agent_versions with the project convention used by
+notifications, attachments, knowledge_documents, etc., where tenant_id
+is a plain Integer column (0 = platform-level) without FK constraints.
+
+Fixes #1
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260610_0048_drop_av_tenant_fk"
+down_revision: str | Sequence[str] | None = "20260530_0047_ann_pending_idx"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Remove FK constraint on agent_versions.tenant_id."""
+    op.drop_constraint(
+        "agent_versions_tenant_id_fkey",
+        "agent_versions",
+        type_="foreignkey",
+    )
+
+
+def downgrade() -> None:
+    """Restore FK constraint on agent_versions.tenant_id."""
+    op.create_foreign_key(
+        "agent_versions_tenant_id_fkey",
+        "agent_versions",
+        "tenants",
+        ["tenant_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )


### PR DESCRIPTION
Fixes #1

## 问题

管理端发布平台级智能体（`owner_tenant_id=NULL`）时，`publish_agent` 使用 `PLATFORM_TENANT_ID = 0` 作为 `agent_versions.tenant_id`，但该列有外键约束 `-> tenants.id`，数据库中不存在 `id=0` 的租户记录，导致 PostgreSQL `IntegrityError`。

## 修复

新增 Alembic 迁移 `20260610_0048_drop_av_tenant_fk`，移除 `agent_versions.tenant_id` 的外键约束，与项目中 `notifications`、`attachments` 等表的惯例保持一致（`tenant_id` 为普通 Integer，0 = 平台级）。

## 变更文件

- `backend/migrations/versions/20260610_0048_drop_av_tenant_fk.py` — 新增迁移

## 验收

- [x] 迁移链 `alembic heads` 正确
- [x] 现有 agent 服务测试全部通过（25/25）
- [x] revision ID 长度合规（≤32字符）
- [ ] 生产环境执行迁移后，平台级智能体可正常发布