### PR TITLE
[fix] Celery Worker 添加 --pool=solo 避免 PyMuPDF fork SIGSEGV

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -65,7 +65,7 @@ CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--worker
 
 FROM runtime AS worker
 
-CMD ["celery", "-A", "app.celery_app:celery_app", "worker", "--loglevel=info"]
+CMD ["celery", "-A", "app.celery_app:celery_app", "worker", "--loglevel=info", "--pool=solo"]
 
 FROM runtime AS beat
 


### PR DESCRIPTION
Fixes #11

## 变更内容

Dockerfile worker 阶段添加 `--pool=solo` 参数，避免 PyMuPDF (fitz) 原生 C 扩展与 Celery prefork 池的 fork 不兼容问题。

## 问题

- Celery 默认使用 prefork 池（基于 fork 的多进程）
- PyMuPDF 的 C 库内部状态在 fork 后不一致
- 处理 RAG 文档时触发 SIGSEGV (Signal 11) 导致 Worker 崩溃

## 修复

- 使用 solo 池（单进程模式）彻底避免 fork
- 如需并发，通过 `docker compose --scale backend-worker=N` 扩展容器数