### PR TITLE
[fix] process_document 任务添加 RedisManager 懒初始化

### DIFF
--- a/backend/app/ai/rag/processor.py
+++ b/backend/app/ai/rag/processor.py
@@ -132,6 +132,15 @@ def process_document(self: TenantTask, tenant_id: int | None, document_id: int) 
 
         await async_engine.dispose()
 
+        # Ensure Redis is initialized in Celery worker context
+        # (RedisManager.init() only runs in FastAPI lifespan, not in worker process)
+        # 确保 Celery Worker 上下文中 Redis 已初始化
+        # （RedisManager.init() 仅在 FastAPI lifespan 中调用，Worker 进程不会执行）
+        from app.core.redis import RedisManager
+
+        if RedisManager._pool is None:
+            await RedisManager.init()
+
         # Ensure AI adapters are registered (Celery worker may not have loaded registrations from celery_app.py)
         # 确保 AI 适配器已注册（Celery worker 可能未加载 celery_app.py 中的注册）
         from app.ai.adapters import AdapterRegistry, register_core_adapters


### PR DESCRIPTION
Fixes #13

## 变更内容

在 `backend/app/ai/rag/processor.py` 的 `_execute()` 函数中添加 `RedisManager` 懒初始化。

## 问题

- `RedisManager.init()` 仅在 FastAPI lifespan 中调用
- Celery Worker 是独立进程，`_client` 始终为 `None`
- `_report_progress()` → `cache_set()` → `RedisManager.get_client()` 抛出 RuntimeError
- 文档处理任务以 `status: error` 结束，实际文档可能已处理成功

## 修复

- 在 `_execute()` 开头检查 `RedisManager._pool`，若未初始化则调用 `init()`
- 复用 `scheduled.py` 中已有的懒初始化模式