### PR TITLE
[fix] document_chunk 模型 content_tsv 声明为 Computed 兼容 GENERATED ALWAYS 列

### DIFF
--- a/backend/app/models/ai/document_chunk.py
+++ b/backend/app/models/ai/document_chunk.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     Column,
+    Computed,
     ForeignKey,
     Index,
     Integer,
@@ -120,12 +121,12 @@ class DocumentChunk(TenantModel):
 
     # ==================== 全文检索 ==================== / Full-text search
 
-    # tsvector 列，由 DB trigger trg_document_chunks_tsv 自动维护 /
-    # tsvector maintained by trigger
+    # tsvector 列，由 PostgreSQL GENERATED ALWAYS AS 自动维护 / 
+    # tsvector maintained automatically via GENERATED ALWAYS AS (STORED)
     # 用于 KeywordSearcher 全文检索 / Used by KeywordSearcher
     content_tsv = mapped_column(
         TSVECTOR,
-        nullable=True,
+        Computed("to_tsvector('simple', content)", persisted=True),
     )
 
     # ==================== 元数据 ==================== / Chunk metadata


### PR DESCRIPTION
Fixes #15

## 变更内容

`backend/app/models/ai/document_chunk.py` 中 `content_tsv` 列添加 `Computed()` 声明。

## 问题

- 数据库迁移定义 `content_tsv` 为 `GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED`
- 模型中映射为普通 `TSVECTOR` 列
- `create_many()` 批量写入时 SQLAlchemy 在 INSERT 中包含该列（值 None）
- PostgreSQL 拒绝向 GENERATED ALWAYS 列显式插入值

## 修复

- 使用 `Computed("to_tsvector('simple', content)", persisted=True)`
- SQLAlchemy 自动在 INSERT/UPDATE 中排除该列