### PR TITLE
feat(ai-panel): 路由切换时实时刷新页面上下文 pageContext

### DIFF
--- a/frontend/apps/web-antd/src/components/business/ai-slide-panel/use-panel-context-bridge.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-slide-panel/use-panel-context-bridge.ts
@@ -3,9 +3,10 @@ import type { Ref } from 'vue';
 import type { InputVariable } from '#/types/ai-chat';
 
 import { computed, onMounted, reactive, ref, watch } from 'vue';
-
-import { message } from 'ant-design-vue';
 import { useRoute } from 'vue-router';
+
+import { useDebounceFn } from '@vueuse/core';
+import { message } from 'ant-design-vue';
 
 import { $t } from '#/locales';
 import { collectCurrentPageContext } from '#/utils/page-context-collector';
@@ -338,11 +339,10 @@ export function usePanelContextBridge(options: UsePanelContextBridgeOptions) {
     // 收集当前页面上下文并存入 store / Collect current page context
     try {
       const ctx = collectCurrentPageContext(route);
-      console.debug('[AI Panel] Collected page context:', ctx);
       options.onPageContextCollected?.(ctx);
-    } catch (err) {
+    } catch (error) {
       // collectCurrentPageContext may fail outside Vue component context
-      console.warn('[AI Panel] Failed to collect page context:', err);
+      console.warn('[AI Panel] Failed to collect page context:', error);
     }
 
     const pendingAgentId = consumeQueuedPendingAgentId();
@@ -420,6 +420,35 @@ export function usePanelContextBridge(options: UsePanelContextBridgeOptions) {
       }
     },
     { flush: 'sync' },
+  );
+
+  // ── Route change watcher: refresh pageContext when route changes while panel is open ──
+  // ── 路由变化监听器：面板打开期间路由切换时自动刷新页面上下文 ──
+  const debouncedRefreshPageContext = useDebounceFn(() => {
+    if (!options.visible.value) {
+      return;
+    }
+    try {
+      const ctx = collectCurrentPageContext(route);
+      options.onPageContextCollected?.(ctx);
+    } catch (error) {
+      console.warn(
+        '[AI Panel] Failed to refresh page context on route change:',
+        error,
+      );
+    }
+  }, 300);
+
+  watch(
+    () => route.path,
+    () => {
+      // Only refresh when panel is visible; next open will re-collect anyway
+      // 仅在面板可见时刷新；下次打开时会重新采集
+      if (options.visible.value) {
+        void debouncedRefreshPageContext();
+      }
+    },
+    { flush: 'post' },
   );
 
   watch(options.visible, (visible) => {


### PR DESCRIPTION
## 改动说明

Fixes #6

在 `use-panel-context-bridge.ts` 中新增 `route.path` watcher，实现 AI 侧边栏面板打开期间路由切换时自动刷新 `pageContext`，确保每轮对话携带的页面上下文始终反映用户当前所在页面。

### 核心变更

| 文件 | 改动 |
|---|---|
| `use-panel-context-bridge.ts` | 新增 `route.path` watcher + `useDebounceFn`（300ms）防抖刷新 |

### 实现要点

1. **路由监听** — `watch(() => route.path, ...)` 在面板可见时触发防抖刷新
2. **防抖 300ms** — 使用 `@vueuse/core` 的 `useDebounceFn`，避免快速 Tab 切换时频繁调用
3. **条件刷新** — 仅在 `visible === true` 时刷新；面板关闭后下次打开会重新采集
4. **不影响流式请求** — 上下文存入 store，仅下一轮对话读取新值
5. **不重新触发欢迎语** — watcher 仅刷新 `pageContext`，不涉及欢迎语逻辑
6. **附带修复** — 清理预存 lint 问题（import 排序、`console.debug`、`err` 命名）

### 验收对照

- [x] 面板打开期间切换页面，`aiPanelStore.pageContext` 实时更新
- [x] 新页面第一轮对话携带正确上下文
- [x] 路由快速切换不产生大量重复请求
- [x] 进行中的流式请求不受影响

### 测试验证

已在租户端和管理端两个业务场景验证：
- 租户端：组织架构 → 系统配置，AI 正确识别 `/tenant/system-mgmt/configs`
- 管理端：知识库 → 功能分配，AI 正确识别 `/admin/ai/agent-assignments`

### 类型检查 & Lint

- `vue-tsc --noEmit` ✅ 通过
- `eslint` ✅ 零错误零警告
