### PR TITLE
feat(ai-panel): 点击AI图标默认打开对应端Copilot智能体会话

### DIFF
--- a/frontend/apps/web-antd/src/api/shared/ai-chat.ts
+++ b/frontend/apps/web-antd/src/api/shared/ai-chat.ts
@@ -560,3 +560,32 @@ export async function generateWelcomeMessageApi(
     body,
   );
 }
+
+// ============ Default Copilot Resolve / 默认 Copilot 解析 ============
+
+export interface DefaultCopilotResponse {
+  agent_id: null | number;
+  agent_name: null | string;
+  config: null | Record<string, unknown>;
+  feature_code: string;
+  is_active: boolean;
+}
+
+/**
+ * Resolve default Copilot agent by feature_code / 按功能代码解析默认 Copilot 智能体
+ *
+ * @param apiPrefix - API prefix (/admin or /tenant)
+ * @param featureCode - Feature code (admin_copilot or tenant_copilot)
+ */
+export async function resolveDefaultCopilotApi(
+  apiPrefix: string,
+  featureCode: string,
+): Promise<DefaultCopilotResponse> {
+  return requestClient.get<DefaultCopilotResponse>(
+    `${apiPrefix}/ai/agent-assignments/resolve/${featureCode}`,
+    {
+      showCodeMessage: false,
+      showErrorMessage: false,
+    },
+  );
+}

--- a/frontend/apps/web-antd/src/composables/use-default-copilot.ts
+++ b/frontend/apps/web-antd/src/composables/use-default-copilot.ts
@@ -1,0 +1,72 @@
+/**
+ * Default Copilot composable / 默认 Copilot 组合式函数
+ *
+ * Resolves and caches the default Copilot agent ID based on the current API prefix.
+ * Admin endpoint → admin_copilot; Tenant endpoint → tenant_copilot.
+ * 根据当前 API 前缀解析并缓存默认 Copilot 智能体 ID。
+ */
+import type { ComputedRef } from 'vue';
+
+import { ref, watch } from 'vue';
+
+import { resolveDefaultCopilotApi } from '#/api/shared/ai-chat';
+
+/** Feature code constants / 功能代码常量 */
+const FEATURE_CODE_ADMIN = 'admin_copilot';
+const FEATURE_CODE_TENANT = 'tenant_copilot';
+
+function resolveFeatureCode(apiPrefix: string): string {
+  return apiPrefix === '/admin' ? FEATURE_CODE_ADMIN : FEATURE_CODE_TENANT;
+}
+
+export function useDefaultCopilot(apiPrefix: ComputedRef<string> | string) {
+  const defaultCopilotAgentId = ref<null | number>(null);
+  const defaultCopilotAgentName = ref<null | string>(null);
+  const resolving = ref(false);
+
+  async function resolveDefaultCopilot(): Promise<void> {
+    const prefix = typeof apiPrefix === 'string' ? apiPrefix : apiPrefix.value;
+    const featureCode = resolveFeatureCode(prefix);
+
+    resolving.value = true;
+    try {
+      const result = await resolveDefaultCopilotApi(prefix, featureCode);
+      if (result?.is_active && result.agent_id) {
+        defaultCopilotAgentId.value = result.agent_id;
+        defaultCopilotAgentName.value = result.agent_name;
+      } else {
+        defaultCopilotAgentId.value = null;
+        defaultCopilotAgentName.value = null;
+      }
+    } catch {
+      // Silently fail — fallback to existing behavior (first agent in list)
+      // 静默失败 — 回退至现有行为（列表首个智能体）
+      defaultCopilotAgentId.value = null;
+      defaultCopilotAgentName.value = null;
+    } finally {
+      resolving.value = false;
+    }
+  }
+
+  // Clear cache when apiPrefix changes / API 前缀变化时清除缓存
+  watch(
+    () => (typeof apiPrefix === 'string' ? apiPrefix : apiPrefix.value),
+    () => {
+      defaultCopilotAgentId.value = null;
+      defaultCopilotAgentName.value = null;
+      void resolveDefaultCopilot();
+    },
+    { immediate: true },
+  );
+
+  return {
+    /** Resolved default Copilot agent ID / 已解析的默认 Copilot 智能体 ID */
+    defaultCopilotAgentId,
+    /** Resolved default Copilot agent name / 已解析的默认 Copilot 智能体名称 */
+    defaultCopilotAgentName,
+    /** Whether resolving is in progress / 是否正在解析中 */
+    resolving,
+    /** Re-resolve the default Copilot / 重新解析默认 Copilot */
+    resolveDefaultCopilot,
+  };
+}

--- a/frontend/apps/web-antd/src/layouts/basic.vue
+++ b/frontend/apps/web-antd/src/layouts/basic.vue
@@ -34,6 +34,7 @@ import PluginFloatingPanels from '#/components/business/plugin-slots/PluginFloat
 import ReLoginForm from '#/components/business/re-login-form/ReLoginForm.vue';
 import { GlobalPlainTextInputAiAssist } from '#/components/business/text-selection-ai-assist';
 import { useAIEntryPolicy } from '#/composables';
+import { useDefaultCopilot } from '#/composables/use-default-copilot';
 import {
   refreshPluginSlots,
   resetPluginRoutesReady,
@@ -92,6 +93,22 @@ const apiPrefix = computed(() => {
   if (path.startsWith('/tenant')) return '/tenant';
   return '/tenant';
 });
+
+// ============ Default Copilot / 默认 Copilot 智能体 ============
+
+const { defaultCopilotAgentId } = useDefaultCopilot(apiPrefix);
+
+/** AI icon click handler: pinned > defaultCopilot > fallback / AI 图标点击：已 Pin > 默认 Copilot > 回退 */
+function onAIIConClick() {
+  const pinnedId = aiPanelStore.pinnedAgentId;
+  if (pinnedId) {
+    aiPanelStore.openWithContext({ agentId: pinnedId });
+  } else if (defaultCopilotAgentId.value) {
+    aiPanelStore.openWithContext({ agentId: defaultCopilotAgentId.value });
+  } else {
+    aiPanelStore.open();
+  }
+}
 
 // ============ Endpoint Indicator / 当前端点标识 ============
 
@@ -609,7 +626,7 @@ watch(
       >
         <div
           class="mr-1 flex cursor-pointer items-center justify-center rounded-md p-1.5 transition-colors hover:bg-accent"
-          @click="aiPanelStore.open()"
+          @click="onAIIConClick"
         >
           <IconifyIcon icon="lucide:bot" class="size-4" />
         </div>


### PR DESCRIPTION
## 概述

Fixes #7

点击顶部导航栏 AI 图标时，根据当前端点（管理端/租户端）自动打开对应的默认 Copilot 智能体会话，无需用户手动选择。

## 变更说明

| 文件 | 改动 |
|---|---|
| `api/shared/ai-chat.ts` | 新增 `resolveDefaultCopilotApi(prefix, featureCode)` 调用系统智能体绑定解析接口 |
| `composables/use-default-copilot.ts` | 新建 composable：解析并缓存默认 Copilot agent ID，端点切换时自动刷新 |
| `layouts/basic.vue` | 集成 `useDefaultCopilot`；新增 `onAIIConClick` 处理函数 |

## 逻辑优先级

```
AI 图标点击 → pinnedAgentId（已 Pin）> defaultCopilotAgentId（默认 Copilot）> 原始行为（列表首个）
```

- 管理端 `/admin` → `feature_code=admin_copilot` → **平台运营 Copilot**
- 租户端 `/tenant` → `feature_code=tenant_copilot` → **企业运营 Copilot**
- 后端 `GET /{prefix}/ai/agent-assignments/resolve/{feature_code}` 已就绪，**本次无后端改动**
- API 失败或 Copilot 未配置时静默回退，不影响用户体验

## 验收标准

- [x] 管理端点击 AI 图标，默认打开「平台运营 Copilot」智能体会话
- [x] 租户端点击 AI 图标，默认打开「企业运营 Copilot」智能体会话
- [x] 已 Pin 智能体时，优先使用 Pinned agent
- [x] 默认 Copilot 未配置或不可用时，回退到现有行为（列表第一个）
- [x] 端点切换时自动重新解析（管理端 ↔ 租户端）

## 检查结果

- [x] vue-tsc 类型检查通过
- [x] ESLint 检查通过