### PR TITLE
fix(ai-panel): 新建会话时使用当前选中的智能体发送消息

### DIFF
--- a/frontend/apps/web-antd/src/components/business/ai-slide-panel/use-panel-send-message.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-slide-panel/use-panel-send-message.ts
@@ -158,13 +158,10 @@ export function usePanelSendMessage(options: UsePanelSendMessageOptions) {
       options.forceRerouteNextTurn.value = false;
     }
 
-    if (
-      !options.activeConversationId.value &&
-      options.manualNewConversationAgentId.value &&
-      options.selectedAgentId.value ===
-        options.manualNewConversationAgentId.value
-    ) {
-      const explicitAgentId = options.manualNewConversationAgentId.value;
+    // New conversation with explicit agent selection (manual or default copilot)
+    // 新建会话且有明确选中的智能体（手动选择或默认 Copilot）→ 直接发送，无需路由
+    if (!options.activeConversationId.value && options.selectedAgentId.value) {
+      const explicitAgentId = options.selectedAgentId.value;
       options.manualNewConversationAgentId.value = null;
       return options.sendMessage({
         agentId: explicitAgentId,


### PR DESCRIPTION
## 问题

Fixes #30

点击 AI 图标打开默认 Copilot 后，在同一会话中记忆正常工作。但点击「新建会话」按钮后：
1. 弹出提示「路由未命中，已用当前智能体发送」
2. 智能体记忆无法读取

## 根因

`use-panel-send-message.ts` 中新建会话的判断条件过于严格：

```ts
// 旧逻辑：需要 manualNewConversationAgentId 有值且与 selectedAgentId 匹配
if (!activeConversationId && manualNewConversationAgentId && selectedAgentId === manualNewConversationAgentId) {
  // 直接发送
}
```

但点击「新建会话」按钮时 `manualNewConversationAgentId` 不会被设置，导致条件失败，回退到路由 API（可能失败）。

## 修复

简化判断逻辑：当 `activeConversationId` 为空且有 `selectedAgentId` 时，直接使用该智能体发送：

```ts
// 新逻辑：新建会话且有明确选中的智能体 → 直接发送
if (!activeConversationId && selectedAgentId) {
  sendMessage({ agentId: selectedAgentId });
}
```

## 变更文件

| 文件 | 改动 |
|---|---|
| `use-panel-send-message.ts` | 简化新建会话发送逻辑，使用 `selectedAgentId` 直接发送 |

## 验收标准

- [x] 新建会话后发送消息，不再弹出「路由未命中」警告
- [x] 新建会话后发送消息，正确使用当前选中的默认 Copilot 智能体
- [x] 智能体记忆在新会话中正常读取
- [x] vue-tsc 类型检查通过
- [x] ESLint 检查通过