### PR TITLE
fix(scope): extractScopePayload 在 withTenantId=false 时不输出 tenant_id 键

### DIFF
--- a/frontend/apps/web-antd/src/components/business/scope-select/use-scope-fields.ts
+++ b/frontend/apps/web-antd/src/components/business/scope-select/use-scope-fields.ts
@@ -210,11 +210,14 @@ export function extractScopePayload(
   const scope = values[scopeField] as string;
   const result: Record<string, unknown> = {
     [scopeField]: scope,
-    tenant_id:
-      withTenantId && scope === 'all_tenants'
-        ? (values.tenant_id ?? null)
-        : null,
   };
+
+  // Only include tenant_id when explicitly requested (withTenantId=true)
+  // 仅在显式要求时包含 tenant_id，避免触发后端废弃字段校验
+  if (withTenantId) {
+    result.tenant_id =
+      scope === 'all_tenants' ? (values.tenant_id ?? null) : null;
+  }
 
   if (scopeNeedsAssignment(scope)) {
     result.tenant_ids = values.tenant_ids ?? [];


### PR DESCRIPTION
## 问题

Fixes #10

管理端创建知识库时报错：

```json
{
  "field": "body",
  "message": "字段 'tenant_id' 已废弃且不再接受，请从请求中移除。"
}
```

## 根因

`extractScopePayload()` 在 `withTenantId=false` 时仍然在返回对象中包含 `tenant_id: null` 键，被后端 `_RejectRetiredAdminKnowledgeBaseAliases` 校验器拒绝（检查键是否存在，不检查值）。

## 修复

修改 `extractScopePayload()` 逻辑：仅在 `withTenantId=true` 时才在返回对象中包含 `tenant_id` 键。

```ts
// 修改前：始终包含 tenant_id（即使为 null）
const result = {
  [scopeField]: scope,
  tenant_id: withTenantId && scope === 'all_tenants' ? values.tenant_id : null,  // ❌
};

// 修改后：仅在显式要求时包含
const result = { [scopeField]: scope };
if (withTenantId) {
  result.tenant_id = scope === 'all_tenants' ? values.tenant_id : null;  // ✅
}
```

## 变更文件

| 文件 | 改动 |
|---|---|
| `use-scope-fields.ts` | `extractScopePayload` 条件输出 `tenant_id` |

## 验收标准

- [x] `withTenantId=false` 时不输出 `tenant_id` 键
- [x] `withTenantId=true` 时行为不变
- [x] vue-tsc 类型检查通过
- [x] ESLint 检查通过