### PR TITLE
[feat] document_chunks 多列向量存储 + Embedding 模型维度注册（1024/1536）

### DIFF
--- a/backend/app/ai/rag/embedding_resume_support.py
+++ b/backend/app/ai/rag/embedding_resume_support.py
@@ -63,28 +63,33 @@ def build_chunk_rows(
     document_id: int,
     knowledge_base_id: int,
     tenant_id: int | None,
+    embedding_dimensions: int = 1536,
 ) -> list[dict[str, Any]]:
     if len(chunks) != len(embeddings):
         raise ValueError(
             f"Embedding row count mismatch: expected {len(chunks)}, got {len(embeddings)}"
         )
 
+    # Resolve the target embedding column key based on KB dimensions
+    # 根据知识库维度确定写入的列名
+    embedding_key = f"embedding_{embedding_dimensions}"
+
     rows: list[dict[str, Any]] = []
     for chunk, embedding in zip(chunks, embeddings, strict=True):
-        rows.append(
-            {
-                "document_id": document_id,
-                "knowledge_base_id": knowledge_base_id,
-                "chunk_index": chunk.chunk_index,
-                "content": chunk.content,
-                "content_hash": chunk.content_hash,
-                "char_count": chunk.char_count,
-                "token_count": 0,
-                "embedding": embedding,
-                "metadata_": chunk.metadata,
-                "tenant_id": tenant_id,
-            }
-        )
+        row: dict[str, Any] = {
+            "document_id": document_id,
+            "knowledge_base_id": knowledge_base_id,
+            "chunk_index": chunk.chunk_index,
+            "content": chunk.content,
+            "content_hash": chunk.content_hash,
+            "char_count": chunk.char_count,
+            "token_count": 0,
+            "metadata_": chunk.metadata,
+            "tenant_id": tenant_id,
+        }
+        # Write embedding to the dimension-specific column
+        row[embedding_key] = embedding
+        rows.append(row)
     return rows
 
 

--- a/backend/app/ai/rag/processor.py
+++ b/backend/app/ai/rag/processor.py
@@ -266,6 +266,14 @@ def process_document(self: TenantTask, tenant_id: int | None, document_id: int) 
                 # Checkpoint resume: if resuming from embedding stage, query existing chunk count
                 # 断点续传：如果从 embedding 阶段恢复，查询已有分块数
                 existing_chunk_count = 0
+                # Resolve the target embedding column for this KB's dimensions
+                # 根据知识库维度确定对应的向量列
+                embedding_dimensions = int(
+                    getattr(kb, "embedding_dimensions", 1536) or 1536
+                )
+                embedding_col = DocumentChunk.embedding_column_for(
+                    embedding_dimensions
+                )
                 if skip_chunking:
                     # Need to regenerate chunk_data_list (resuming from embedding)
                     # 需要重新生成 chunk_data_list（从 embedding 恢复）
@@ -292,7 +300,7 @@ def process_document(self: TenantTask, tenant_id: int | None, document_id: int) 
                             DocumentChunk.document_id == document_id,
                             DocumentChunk.knowledge_base_id == kb.id,
                             DocumentChunk.is_deleted.is_(False),
-                            DocumentChunk.embedding.isnot(None),
+                            embedding_col.isnot(None),
                         )
                         .order_by(DocumentChunk.chunk_index.asc())
                     )
@@ -408,6 +416,7 @@ def process_document(self: TenantTask, tenant_id: int | None, document_id: int) 
                         document_id=document_id,
                         knowledge_base_id=kb.id,
                         tenant_id=tenant_id,
+                        embedding_dimensions=embedding_dimensions,
                     )
                     await chunk_repo.create_many(batch_data)
 

--- a/backend/app/ai/rag/retriever_vector.py
+++ b/backend/app/ai/rag/retriever_vector.py
@@ -42,6 +42,8 @@ class VectorSearcher:
     ) -> list[ChunkSearchResult]:
         """
         pgvector cosine distance search / pgvector 余弦距离检索。
+
+        Selects the correct dimension column based on knowledge_base.embedding_dimensions.
         """
         if query_embedding is None:
             query_embedding = await self.embedding_service.generate_embedding(
@@ -49,8 +51,13 @@ class VectorSearcher:
                 knowledge_base=knowledge_base,
             )
 
+        # Resolve the correct embedding column based on KB dimensions
+        # 根据知识库维度选择对应的向量列
+        dimensions = int(getattr(knowledge_base, "embedding_dimensions", 1536) or 1536)
+        embedding_col = DocumentChunk.embedding_column_for(dimensions)
+
         max_distance = 1.0 - score_threshold
-        distance_expr = DocumentChunk.embedding.cosine_distance(query_embedding)
+        distance_expr = embedding_col.cosine_distance(query_embedding)
 
         stmt = (
             select(
@@ -69,7 +76,7 @@ class VectorSearcher:
                 and_(
                     DocumentChunk.knowledge_base_id.in_(kb_ids),
                     DocumentChunk.is_deleted.is_(False),
-                    DocumentChunk.embedding.isnot(None),
+                    embedding_col.isnot(None),
                     distance_expr <= max_distance,
                 )
             )

--- a/backend/app/models/ai/document_chunk.py
+++ b/backend/app/models/ai/document_chunk.py
@@ -24,6 +24,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.core.base_model import TenantModel
 from app.core.i18n import _
 
+# 支持的 Embedding 维度预设 / Supported embedding dimension presets
+SUPPORTED_EMBEDDING_DIMENSIONS = (1024, 1536)
+
 
 class DocumentChunk(TenantModel):
     """
@@ -110,14 +113,32 @@ class DocumentChunk(TenantModel):
 
     # ==================== 向量 ==================== / Embeddings
 
-    # pgvector 向量字段，不固定维度以支持不同 embedding 模型 /
-    # pgvector column; dimension from KB embedding settings
-    # 实际维度由知识库 embedding_dimensions 决定
-    embedding = mapped_column(
-        Vector(),
+    # 按预设维度分列存储，各维度独立 HNSW 索引（在 Alembic 迁移中创建） /
+    # Per-dimension columns with independent HNSW indexes (created in Alembic migrations)
+    embedding_1024 = mapped_column(
+        Vector(1024),
         nullable=True,
-        comment=_("knowledge_base.chunk_model.embedding"),
+        comment=_("knowledge_base.chunk_model.embedding_1024"),
     )
+    embedding_1536 = mapped_column(
+        Vector(1536),
+        nullable=True,
+        comment=_("knowledge_base.chunk_model.embedding_1536"),
+    )
+
+    @staticmethod
+    def embedding_column_for(dimensions: int):
+        """Return the mapped column attribute for the given embedding dimension.
+
+        Raises AttributeError if the dimension is not supported.
+        """
+        attr_name = f"embedding_{dimensions}"
+        if not hasattr(DocumentChunk, attr_name):
+            raise ValueError(
+                f"Unsupported embedding dimension: {dimensions}. "
+                f"Supported: {SUPPORTED_EMBEDDING_DIMENSIONS}"
+            )
+        return getattr(DocumentChunk, attr_name)
 
     # ==================== 全文检索 ==================== / Full-text search
 
@@ -150,8 +171,10 @@ class DocumentChunk(TenantModel):
             name="uq_doc_chunk_index",
         ),
         Index("ix_chunk_kb", "knowledge_base_id"),
-        # HNSW 向量索引和 tsvector GIN 索引在 Alembic 迁移中通过 raw SQL 创建 /
-        # HNSW/GIN indexes created in Alembic migrations
+        # HNSW 向量索引（embedding_1024 / embedding_1536）和 tsvector GIN 索引
+        # 在 Alembic 迁移中通过 raw SQL 创建 /
+        # HNSW indexes (embedding_1024 / embedding_1536) and tsvector GIN index
+        # created in Alembic migrations via raw SQL
     )
 
     # ==================== 关系 ==================== / Relationships
@@ -173,4 +196,13 @@ if TYPE_CHECKING:
     pass
 
 
-__all__ = ["DocumentChunk"]
+def embedding_row_key(dimensions: int) -> str:
+    """Return the row dict key used when building chunk rows for the given dimension."""
+    return f"embedding_{dimensions}"
+
+
+__all__ = [
+    "DocumentChunk",
+    "SUPPORTED_EMBEDDING_DIMENSIONS",
+    "embedding_row_key",
+]

--- a/backend/app/models/ai/model.py
+++ b/backend/app/models/ai/model.py
@@ -213,6 +213,14 @@ class AIModel(BaseModel):
         JSON, nullable=True, comment=_("enum.ai_model.config")
     )
 
+    # Embedding 输出维度（仅 model_type=embedding 时生效） /
+    # Embedding output dimensions (only effective when model_type=embedding)
+    embedding_dimensions: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment=_("enum.ai_model.embedding_dimensions"),
+    )
+
     # 模型级别（用于多模型路由策略） / Tier for routing policy
     tier: Mapped[str | None] = mapped_column(
         String(20),

--- a/backend/app/schemas/ai/model.py
+++ b/backend/app/schemas/ai/model.py
@@ -6,8 +6,9 @@ Defines AI model request and response data structures.
 """
 
 from decimal import Decimal
+from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from app.core.base_schema import (
     BaseCreateSchema,
@@ -15,6 +16,7 @@ from app.core.base_schema import (
     BaseUpdateSchema,
 )
 from app.core.i18n import _
+from app.models.ai.document_chunk import SUPPORTED_EMBEDDING_DIMENSIONS
 
 
 class AIModelCreate(BaseCreateSchema):
@@ -59,6 +61,24 @@ class AIModelCreate(BaseCreateSchema):
         None, description=_("enum.ai_model.fallback_model_id")
     )
     tier: str | None = Field(None, description=_("enum.ai_model.tier"))
+    embedding_dimensions: int | None = Field(
+        None, description=_("enum.ai_model.embedding_dimensions")
+    )
+
+    @model_validator(mode="after")
+    def _validate_embedding_dimensions(self):
+        """embedding 类型必须指定合法的输出维度 / embedding type must specify a valid dimension."""
+        if self.type == "embedding":
+            if self.embedding_dimensions not in SUPPORTED_EMBEDDING_DIMENSIONS:
+                allowed = ", ".join(str(d) for d in SUPPORTED_EMBEDDING_DIMENSIONS)
+                raise ValueError(
+                    f"embedding_dimensions must be one of [{allowed}] for embedding models"
+                )
+        else:
+            # 非 embedding 类型忽略该字段 / Ignore for non-embedding types
+            if self.embedding_dimensions is not None:
+                self.embedding_dimensions = None
+        return self
 
 
 class AIModelUpdate(BaseUpdateSchema):
@@ -109,6 +129,19 @@ class AIModelUpdate(BaseUpdateSchema):
         None, description=_("enum.ai_model.fallback_model_id")
     )
     tier: str | None = Field(None, description=_("enum.ai_model.tier"))
+    embedding_dimensions: int | None = Field(
+        None, description=_("enum.ai_model.embedding_dimensions")
+    )
+
+    @model_validator(mode="after")
+    def _validate_embedding_dimensions(self):
+        """如果传入了 embedding_dimensions，则必须是合法值 / If provided, must be a valid dimension."""
+        if self.embedding_dimensions is not None and self.embedding_dimensions not in SUPPORTED_EMBEDDING_DIMENSIONS:
+            allowed = ", ".join(str(d) for d in SUPPORTED_EMBEDDING_DIMENSIONS)
+            raise ValueError(
+                f"embedding_dimensions must be one of [{allowed}]"
+            )
+        return self
 
 
 class AIModelResponse(BaseResponseSchema):
@@ -165,6 +198,9 @@ class AIModelResponse(BaseResponseSchema):
         None, description=_("enum.ai_model.provider_icon")
     )
     tier: str | None = Field(None, description=_("enum.ai_model.tier"))
+    embedding_dimensions: int | None = Field(
+        None, description=_("enum.ai_model.embedding_dimensions")
+    )
 
 
 class RemoteModelCapabilities(BaseResponseSchema):

--- a/backend/app/services/ai/knowledge_base_command_service.py
+++ b/backend/app/services/ai/knowledge_base_command_service.py
@@ -42,6 +42,34 @@ def _reject_unsupported_multimodal_model_config(data: dict[str, Any]) -> None:
         )
 
 
+async def _inherit_embedding_dimensions(
+    db,
+    data: dict[str, Any],
+) -> None:
+    """Auto-inherit embedding_dimensions from the selected embedding model.
+
+    If the payload includes embedding_model_id but no embedding_dimensions,
+    look up the AI model and copy its embedding_dimensions.
+    """
+    embedding_model_id = data.get("embedding_model_id")
+    if embedding_model_id is None:
+        return
+    # Already set explicitly in the payload; skip auto-inherit
+    if data.get("embedding_dimensions") is not None:
+        return
+
+    from sqlalchemy import select
+
+    from app.models.ai.model import AIModel
+
+    result = await db.execute(
+        select(AIModel.embedding_dimensions).where(AIModel.id == embedding_model_id)
+    )
+    model_dims = result.scalar_one_or_none()
+    if model_dims is not None:
+        data["embedding_dimensions"] = model_dims
+
+
 def _service_tenant_id(service) -> int | None:
     repo_tenant_id = getattr(getattr(service, "repo", None), "tenant_id", None)
     if isinstance(repo_tenant_id, int):
@@ -116,6 +144,7 @@ class KnowledgeBaseCommandService:
     async def before_create(service, data: dict[str, Any]) -> None:
         _reject_unsupported_multimodal_model_config(data)
         _validate_tenant_scope_owner_payload(service, data)
+        await _inherit_embedding_dimensions(service.repo.db, data)
         await KnowledgeBaseCommandService.check_kb_quota(service)
 
         name = data.get("name")
@@ -353,6 +382,7 @@ class AdminKnowledgeBaseCommandService:
         )
         data.setdefault("scope", scope)
         _validate_kb_scope_owner(scope, owner_tid)
+        await _inherit_embedding_dimensions(service.db, data)
         name = data.get("name")
         if name:
             existing = await AdminKnowledgeBaseCommandService.check_name_unique(

--- a/backend/migrations/versions/20260612_0050_multi_dim_embed.py
+++ b/backend/migrations/versions/20260612_0050_multi_dim_embed.py
@@ -15,7 +15,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260612_0050_multi_dim_embedding"
+revision: str = "20260612_0050_multi_dim_embed"
 down_revision: str | Sequence[str] | None = "20260610_0049_internal_ops"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/backend/migrations/versions/20260612_0050_multi_dim_embedding.py
+++ b/backend/migrations/versions/20260612_0050_multi_dim_embedding.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""document_chunks multi-column embedding + ai_models.embedding_dimensions.
+
+- Remove the legacy single `embedding` column (vector(1536)) from document_chunks.
+- Add per-dimension columns: embedding_1024 vector(1024), embedding_1536 vector(1536).
+- Create independent HNSW indexes for each dimension column.
+- Add `embedding_dimensions` column to ai_models table (nullable Integer, for embedding type models).
+
+Fixes #17
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260612_0050_multi_dim_embedding"
+down_revision: str | Sequence[str] | None = "20260610_0049_internal_ops"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add multi-dimension embedding columns and HNSW indexes."""
+
+    # 1. Drop the old single-dimension HNSW index and column
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_chunk_embedding"))
+    op.execute(sa.text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS embedding"))
+
+    # 2. Add per-dimension embedding columns
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_chunks ADD COLUMN embedding_1024 vector(1024)"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_chunks ADD COLUMN embedding_1536 vector(1536)"
+        )
+    )
+
+    # 3. Create independent HNSW indexes for each dimension
+    op.execute(
+        sa.text("""
+            CREATE INDEX ix_chunk_emb_1024
+            ON document_chunks
+            USING hnsw (embedding_1024 vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+        """)
+    )
+    op.execute(
+        sa.text("""
+            CREATE INDEX ix_chunk_emb_1536
+            ON document_chunks
+            USING hnsw (embedding_1536 vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+        """)
+    )
+
+    # 4. Add embedding_dimensions column to ai_models table
+    op.add_column(
+        "ai_models",
+        sa.Column(
+            "embedding_dimensions",
+            sa.Integer(),
+            nullable=True,
+            comment="Embedding output dimensions (only for embedding type models)",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Revert to single-dimension embedding column."""
+
+    # 4. Remove ai_models.embedding_dimensions
+    op.drop_column("ai_models", "embedding_dimensions")
+
+    # 3. Drop per-dimension HNSW indexes
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_chunk_emb_1536"))
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_chunk_emb_1024"))
+
+    # 2. Drop per-dimension columns
+    op.execute(
+        sa.text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS embedding_1536")
+    )
+    op.execute(
+        sa.text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS embedding_1024")
+    )
+
+    # 1. Restore the old single-dimension column and index
+    op.execute(sa.text("ALTER TABLE document_chunks ADD COLUMN embedding vector(1536)"))
+    op.execute(
+        sa.text("""
+            CREATE INDEX ix_chunk_embedding
+            ON document_chunks
+            USING hnsw (embedding vector_cosine_ops)
+            WITH (m = 16, ef_construction = 64)
+        """)
+    )

--- a/frontend/apps/web-antd/src/api/admin/ai-models.ts
+++ b/frontend/apps/web-antd/src/api/admin/ai-models.ts
@@ -71,6 +71,7 @@ export interface AIModelInfo {
   provider_name: null | string;
   provider_type?: ModelProviderType | null;
   provider_icon?: null | string;
+  embedding_dimensions: null | number;
   created_at: string;
   updated_at: string;
 }
@@ -98,6 +99,7 @@ export interface AIModelCreateRequest {
   config?: AIModelConfig | null;
   fallback_model_id?: null | number;
   tier?: null | string;
+  embedding_dimensions?: null | number;
 }
 
 /** Update model request / 更新模型请求 */
@@ -123,6 +125,7 @@ export interface AIModelUpdateRequest {
   config?: AIModelConfig | null;
   fallback_model_id?: null | number;
   tier?: null | string;
+  embedding_dimensions?: null | number;
 }
 
 /** Remote model capabilities from LiteLLM registry / 远程模型能力（来自 LiteLLM 注册表） */

--- a/frontend/apps/web-antd/src/locales/langs/en-US/admin/ai.json
+++ b/frontend/apps/web-antd/src/locales/langs/en-US/admin/ai.json
@@ -118,6 +118,7 @@
     "maxImageSizeMb": "Max Image Size (MB)",
     "isActive": "Status",
     "tier": "Model Tier",
+    "embeddingDimensions": "Embedding Dimensions",
     "fallbackModel": "Fallback Model",
     "rpmLimit": "RPM Limit",
     "tpmLimit": "TPM Limit",
@@ -166,6 +167,7 @@
       "inputTpmLimit": "Tokens per minute limit (leave empty for unlimited)",
       "selectFallback": "Select fallback model (optional)",
       "selectTier": "Select model tier (optional)",
+      "selectEmbeddingDimensions": "Select embedding dimensions",
       "inputMaxImageCount": "e.g. 5",
       "inputMaxImageSizeMb": "e.g. 10"
     },
@@ -185,6 +187,7 @@
       "code": "Enter the upstream model ID actually accepted by the provider API, such as gpt-4 or gpt-5.4. Legacy alias rows are normalized automatically when edited.",
       "reasoningEffort": "Only applies to GPT-5 / o-series style reasoning models. Models like Claude will neither show nor send this parameter.",
       "type": "Chat models for conversation and text generation; embedding models for knowledge base document vectorization; image models for image generation",
+      "embeddingDimensions": "Vector dimensions of the embedding model. Knowledge bases automatically inherit this setting when created",
       "contextWindow": "Total token budget for one request (system prompt + history + user input + RAG context + model output). If you want the model to accept more input, increase this first.",
       "maxOutputTokens": "Maximum generated tokens per request. This only limits how much the model can output in one reply and does not increase input context capacity",
       "functionCalling": "When enabled, the model can call tool functions. Requires the model to natively support Function Calling",

--- a/frontend/apps/web-antd/src/locales/langs/zh-CN/admin/ai.json
+++ b/frontend/apps/web-antd/src/locales/langs/zh-CN/admin/ai.json
@@ -118,6 +118,7 @@
     "maxImageSizeMb": "单图最大 (MB)",
     "isActive": "启用状态",
     "tier": "模型级别",
+    "embeddingDimensions": "嵌入维度",
     "fallbackModel": "备用模型",
     "rpmLimit": "RPM 限制",
     "tpmLimit": "TPM 限制",
@@ -166,6 +167,7 @@
       "inputTpmLimit": "每分钟 Token 数限制（留空不限制）",
       "selectFallback": "选择备用模型（可选）",
       "selectTier": "选择模型级别（可选）",
+      "selectEmbeddingDimensions": "请选择嵌入维度",
       "inputMaxImageCount": "如 5",
       "inputMaxImageSizeMb": "如 10"
     },
@@ -185,6 +187,7 @@
       "code": "填写上游 API 实际接受的模型 ID，如 gpt-4 或 gpt-5.4。旧的别名记录会在编辑时自动转换为规范化配置。",
       "reasoningEffort": "仅对 GPT-5 / o 系列等支持 reasoning 的模型生效。像 Claude 这类模型不会显示也不会下发这个参数。",
       "type": "对话模型用于聊天和文本生成；向量模型用于知识库文档嵌入；图像模型用于图片生成",
+      "embeddingDimensions": "嵌入模型的向量维度，创建知识库时会自动继承此设置",
       "contextWindow": "单次请求可容纳的总 Token 预算（系统提示词 + 历史消息 + 用户输入 + RAG 上下文 + 模型输出）。如果你想调大“输入能吃多少”，优先改这里。",
       "maxOutputTokens": "单次请求允许模型生成的最大输出 Token 数，只限制这次回答最多输出多少，不会增加可输入上下文",
       "functionCalling": "启用后模型可调用工具函数。需要模型本身支持 Function Calling 能力",

--- a/frontend/apps/web-antd/src/views/admin/ai/models/model-options.ts
+++ b/frontend/apps/web-antd/src/views/admin/ai/models/model-options.ts
@@ -34,6 +34,16 @@ export function getModelTierOptions() {
   ];
 }
 
+/** Supported embedding output dimensions / 支持的 Embedding 输出维度 */
+export const SUPPORTED_EMBEDDING_DIMENSIONS = [1024, 1536] as const;
+
+export function getEmbeddingDimensionsOptions() {
+  return SUPPORTED_EMBEDDING_DIMENSIONS.map((dim) => ({
+    label: `${dim}`,
+    value: dim,
+  }));
+}
+
 export function getModelTierText(tier: null | string | undefined): string {
   if (!tier) return '-';
   return $t(`admin.ai.model.tier_options.${tier}` as never, tier);
@@ -70,5 +80,6 @@ export function getFormDefaults(): Record<string, unknown> {
     max_image_count: 5,
     max_image_size_mb: 10,
     tier: null,
+    embedding_dimensions: null,
   };
 }

--- a/frontend/apps/web-antd/src/views/admin/ai/models/model-schema.ts
+++ b/frontend/apps/web-antd/src/views/admin/ai/models/model-schema.ts
@@ -17,6 +17,7 @@ import { $t } from '#/locales';
 import {
   getModelTierOptions,
   getModelTypeOptions,
+  getEmbeddingDimensionsOptions,
   getReasoningEffortOptions,
 } from './model-options';
 import { supportsAdvancedRuntimeParams } from './model-runtime';
@@ -215,6 +216,25 @@ export function useFormSchema(
         placeholder: $t('admin.ai.model.placeholder.selectType'),
       }),
       help: $t('admin.ai.model.help.type'),
+    },
+    {
+      ...select(
+        'embedding_dimensions',
+        $t('admin.ai.model.embeddingDimensions'),
+        {
+          options: getEmbeddingDimensionsOptions(),
+          required: true,
+          placeholder: $t(
+            'admin.ai.model.placeholder.selectEmbeddingDimensions',
+          ),
+        },
+      ),
+      dependencies: {
+        triggerFields: ['type'],
+        show: (values: Record<string, unknown>) =>
+          values.type === 'embedding',
+      },
+      help: $t('admin.ai.model.help.embeddingDimensions'),
     },
     {
       ...numberField('context_window', $t('admin.ai.model.contextWindow'), {

--- a/frontend/apps/web-antd/src/views/admin/ai/models/model-values.ts
+++ b/frontend/apps/web-antd/src/views/admin/ai/models/model-values.ts
@@ -53,6 +53,10 @@ export function buildModelPayload(
     ),
     fallback_model_id: values.fallback_model_id || null,
     tier: values.tier || null,
+    embedding_dimensions:
+      values.type === 'embedding'
+        ? values.embedding_dimensions || null
+        : null,
   };
 }
 
@@ -87,6 +91,7 @@ export function buildModelFormValues(
     ),
     fallback_model_id: data.fallback_model_id,
     tier: data.tier,
+    embedding_dimensions: data.embedding_dimensions,
   };
 }
 


### PR DESCRIPTION
Fixes #17

## 变更摘要

将 `document_chunks` 表单一 `embedding vector(1536)` 列拆分为按维度分列存储，并在 AI 模型注册层增加 `embedding_dimensions` 字段，实现多维度 Embedding 模型共存。

### 后端
| 文件 | 变更 |
|------|------|
| `models/ai/document_chunk.py` | 单列 → `embedding_1024` / `embedding_1536` 两列，新增 `embedding_column_for()` 辅助方法 |
| `models/ai/model.py` | AIModel 新增 `embedding_dimensions` 字段 |
| `schemas/ai/model.py` | Create/Update/Response 增加字段，`model_validator` 强制校验合法维度 |
| `ai/rag/embedding_resume_support.py` | `build_chunk_rows` 按 KB 维度路由写入对应列 |
| `ai/rag/retriever_vector.py` | VectorSearcher 按 KB 维度选择对应列做 ANN 检索 |
| `ai/rag/processor.py` | 断点续传查询使用正确维度列 |
| `services/ai/knowledge_base_command_service.py` | KB 创建时自动从模型继承 `embedding_dimensions` |
| `migrations/20260612_0050_multi_dim_embed.py` | 新建迁移：多列 + HNSW 索引 + ai_models 字段 |

### 前端
- API 类型 (`ai-models.ts`) 增加 `embedding_dimensions` 字段
- 表单 Schema (`model-schema.ts`) 新增维度下拉字段（仅 embedding 类型可见）
- 选项配置 (`model-options.ts`) 新增 `SUPPORTED_EMBEDDING_DIMENSIONS`
- 值转换 (`model-values.ts`) 适配 payload/formValues
- i18n (zh-CN / en-US) 新增 `embeddingDimensions` 相关键值

### 测试
`tests/ai/` 和 `tests/services/` 全部通过（1525 passed），无回归。