### PR TITLE
refactor(ai): 工具化 RAG 与记忆为内置上下文技能包

### DIFF
--- a/backend/app/ai/context/assembly_initial_support.py
+++ b/backend/app/ai/context/assembly_initial_support.py
@@ -145,6 +145,7 @@ async def assemble_initial_context_state(
         agent_kb_ids=agent_kb_ids,
         agent_kb_weights=agent_kb_weights,
     )
+    request._has_bound_knowledge_base = bool(kb_selection.merged_kb_ids)
     runtime_model_capabilities = (
         await capability_bridge.resolve_runtime_model_capabilities(agent=agent)
     )

--- a/backend/app/ai/context/assembly_result_support.py
+++ b/backend/app/ai/context/assembly_result_support.py
@@ -95,6 +95,7 @@ def build_context_diagnostics(
             intent.to_dict() if hasattr(intent, "to_dict") else intent
             for intent in (inputs.intent_plan or [])
         ],
+        "intent_flags": dict(inputs.intent_flags or {}),
         "allow_memory_even_if_shortcircuit": bool(
             (inputs.intent_flags or {}).get("allow_memory_even_if_shortcircuit", False)
         ),

--- a/backend/app/ai/context/contributors/rag.py
+++ b/backend/app/ai/context/contributors/rag.py
@@ -43,7 +43,7 @@ class RAGContributor:
         if not enabled:
             return RAGContextContribution(
                 messages=list(messages),
-                rag_retrieval_status="skipped_shortcircuit",
+                rag_retrieval_status="skipped_tool_managed",
             )
 
         from app.ai.rag_injector import inject_rag_context

--- a/backend/app/ai/context/contributors/rag.py
+++ b/backend/app/ai/context/contributors/rag.py
@@ -43,7 +43,7 @@ class RAGContributor:
         if not enabled:
             return RAGContextContribution(
                 messages=list(messages),
-                rag_retrieval_status="skipped_not_knowledge_intent",
+                rag_retrieval_status="skipped_shortcircuit",
             )
 
         from app.ai.rag_injector import inject_rag_context

--- a/backend/app/ai/context/engine.py
+++ b/backend/app/ai/context/engine.py
@@ -219,8 +219,8 @@ class ConversationContextEngine(ContextEngine):
             rag_config=agent.rag_config or {},
             kb_weights=agent_kb_weights,
             enabled=(
-                not intent_flags["all_shortcircuit"]
-                and intent_flags["has_knowledge_intent"]
+                intent_flags["has_bound_kb"]
+                and not intent_flags["should_skip_bound_kb_rag"]
             ),
         )
         messages = list(rag_contribution.messages or messages)

--- a/backend/app/ai/context/engine.py
+++ b/backend/app/ai/context/engine.py
@@ -218,10 +218,7 @@ class ConversationContextEngine(ContextEngine):
             kb_ids=list(merged_kb_ids or []),
             rag_config=agent.rag_config or {},
             kb_weights=agent_kb_weights,
-            enabled=(
-                intent_flags["has_bound_kb"]
-                and not intent_flags["should_skip_bound_kb_rag"]
-            ),
+            enabled=False,
         )
         messages = list(rag_contribution.messages or messages)
         rag_sources = rag_contribution.rag_sources

--- a/backend/app/ai/context/orchestrator.py
+++ b/backend/app/ai/context/orchestrator.py
@@ -14,6 +14,8 @@ from app.ai.memory_policy import resolve_memory_runtime_policy
 class IntentPlanFlags:
     all_shortcircuit: bool
     has_knowledge_intent: bool
+    has_bound_kb: bool
+    should_skip_bound_kb_rag: bool
     has_memory_intent: bool
     memory_context_enabled: bool
     has_memory_save_intent: bool
@@ -28,6 +30,8 @@ class IntentPlanFlags:
         return {
             "all_shortcircuit": self.all_shortcircuit,
             "has_knowledge_intent": self.has_knowledge_intent,
+            "has_bound_kb": self.has_bound_kb,
+            "should_skip_bound_kb_rag": self.should_skip_bound_kb_rag,
             "has_memory_intent": self.has_memory_intent,
             "memory_context_enabled": self.memory_context_enabled,
             "has_memory_save_intent": self.has_memory_save_intent,
@@ -60,6 +64,29 @@ class ContextPipelineOrchestrator:
             bool(getattr(intent, "shortcircuit", False)) for intent in normalized_plan
         )
         has_knowledge_intent = "knowledge_query" in intent_kinds
+        has_bound_kb = bool(
+            request is not None
+            and bool(getattr(request, "_has_bound_knowledge_base", False))
+        )
+        deterministic_shortcircuit_kinds = {
+            "confirmation_replay",
+            "memory_recall",
+            "memory_save",
+            "time_query",
+        }
+        should_skip_bound_kb_rag = bool(normalized_plan) and all(
+            bool(getattr(intent, "shortcircuit", False))
+            and (
+                str(getattr(intent, "kind", "") or "").strip()
+                in deterministic_shortcircuit_kinds
+                or str(
+                    (getattr(intent, "metadata", None) or {}).get("routing_mode")
+                    or ""
+                ).strip()
+                == "deterministic_shortcircuit"
+            )
+            for intent in normalized_plan
+        )
         has_memory_save_intent = "memory_save" in intent_kinds
         has_memory_recall_intent = "memory_recall" in intent_kinds
         memory_policy = resolve_memory_runtime_policy(request)
@@ -88,6 +115,8 @@ class ContextPipelineOrchestrator:
         return IntentPlanFlags(
             all_shortcircuit=all_shortcircuit,
             has_knowledge_intent=has_knowledge_intent,
+            has_bound_kb=has_bound_kb,
+            should_skip_bound_kb_rag=should_skip_bound_kb_rag,
             has_memory_intent=has_memory_intent,
             memory_context_enabled=memory_context_enabled,
             has_memory_save_intent=has_memory_save_intent,

--- a/backend/app/ai/context/orchestrator.py
+++ b/backend/app/ai/context/orchestrator.py
@@ -68,12 +68,7 @@ class ContextPipelineOrchestrator:
             request is not None
             and bool(getattr(request, "_has_bound_knowledge_base", False))
         )
-        deterministic_shortcircuit_kinds = {
-            "confirmation_replay",
-            "memory_recall",
-            "memory_save",
-            "time_query",
-        }
+        deterministic_shortcircuit_kinds = {"confirmation_replay", "time_query"}
         should_skip_bound_kb_rag = bool(normalized_plan) and all(
             bool(getattr(intent, "shortcircuit", False))
             and (
@@ -96,22 +91,14 @@ class ContextPipelineOrchestrator:
         long_term_memory_runtime_enabled = bool(
             memory_policy.long_term_memory_runtime_enabled
         )
-        allow_memory_even_if_shortcircuit = (
-            has_memory_save_intent or has_memory_recall_intent
-        )
         has_memory_intent = bool(has_memory_save_intent or has_memory_recall_intent)
-        memory_context_enabled = bool(
-            has_memory_intent
-            or (memory_policy.memory_context_enabled and not all_shortcircuit)
-        )
-        should_run_memory_profile = has_memory_recall_intent
-        should_run_memory_vector_recall = bool(
-            has_memory_recall_intent
-            or (
-                memory_policy.long_term_memory_recall_state == "enabled"
-                and not all_shortcircuit
-            )
-        )
+        # Long-term memory is now exposed as system context tools. The context
+        # pipeline only reports runtime capability state; read/write decisions
+        # are made by the model via normal tool calls.
+        allow_memory_even_if_shortcircuit = False
+        memory_context_enabled = False
+        should_run_memory_profile = False
+        should_run_memory_vector_recall = False
         return IntentPlanFlags(
             all_shortcircuit=all_shortcircuit,
             has_knowledge_intent=has_knowledge_intent,

--- a/backend/app/ai/context_tools/tools.py
+++ b/backend/app/ai/context_tools/tools.py
@@ -1,0 +1,172 @@
+"""
+System context tool definitions.
+
+These tools expose knowledge-base search and long-term memory operations to the
+LLM as normal tool calls. They are code-defined runtime builtins, separate from
+the internal-ops API meta-tools because they operate on agent context rather
+than management-console APIs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.ai.tools.types import ToolDefinition, ToolParameter
+from app.enums.agent import ToolTypeEnum
+
+CONTEXT_TOOLS_BUILTIN_TYPE = "context_tools"
+CONTEXT_TOOLS_SEMANTIC_FAMILY = "context_tools"
+
+TOOL_SEARCH_AGENT_KNOWLEDGE_BASE = "search_agent_knowledge_base"
+TOOL_SAVE_LONG_TERM_MEMORY = "save_long_term_memory"
+TOOL_RECALL_LONG_TERM_MEMORY = "recall_long_term_memory"
+
+CONTEXT_TOOLS_SEMANTIC_TAGS: list[str] = [
+    "知识库",
+    "资料",
+    "文档",
+    "检索",
+    "查找",
+    "记住",
+    "记忆",
+    "回忆",
+    "偏好",
+    "约束",
+    "事实",
+    "knowledge base",
+    "documents",
+    "search",
+    "memory",
+    "remember",
+    "recall",
+]
+
+
+def build_context_tool_definitions(
+    *,
+    skill: Any | None = None,
+    config: dict[str, Any] | None = None,
+) -> list[ToolDefinition]:
+    base_config = dict(config or {})
+    base_config["builtin_type"] = CONTEXT_TOOLS_BUILTIN_TYPE
+    configured_tools = base_config.get("tools")
+    allowed_tool_names = {
+        str(item or "").strip()
+        for item in configured_tools
+        if str(item or "").strip()
+    } if isinstance(configured_tools, list) else set()
+
+    common: dict[str, Any] = {
+        "tool_type": ToolTypeEnum.CONTEXT_TOOL.value,
+        "config": base_config,
+        "enabled": True,
+        "source_skill_id": getattr(skill, "id", None),
+        "source_skill_name": getattr(skill, "name", None) or "system_context_tools",
+        "source_skill_type": getattr(skill, "type", None) or "builtin",
+        "semantic_family": CONTEXT_TOOLS_SEMANTIC_FAMILY,
+        "semantic_tags": list(CONTEXT_TOOLS_SEMANTIC_TAGS),
+    }
+
+    search_kb = ToolDefinition(
+        name=TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+        description=(
+            "Search the knowledge bases bound to the current agent. Use this "
+            "when the answer may depend on project docs, uploaded files, "
+            "policies, URLs, or domain knowledge not already present in the "
+            "conversation. The tool returns matching snippets and citation "
+            "sources; use the returned evidence when answering."
+        ),
+        parameters=[
+            ToolParameter(
+                name="query",
+                type="string",
+                description="The focused search query to run against bound KBs.",
+                required=True,
+            ),
+            ToolParameter(
+                name="top_k",
+                type="integer",
+                description="Maximum snippets to return. Defaults to agent RAG config.",
+                required=False,
+            ),
+        ],
+        timeout=45,
+        **common,
+    )
+
+    save_memory = ToolDefinition(
+        name=TOOL_SAVE_LONG_TERM_MEMORY,
+        description=(
+            "Save durable user memory for this agent when the user explicitly "
+            "asks you to remember something, or when an important stable "
+            "preference, constraint, decision, or fact should be preserved for "
+            "future turns. Do not save transient chit-chat."
+        ),
+        parameters=[
+            ToolParameter(
+                name="content",
+                type="string",
+                description="The concise memory text to save.",
+                required=True,
+            ),
+            ToolParameter(
+                name="memory_type",
+                type="string",
+                description="Memory category.",
+                required=False,
+                enum=[
+                    "preference",
+                    "constraint",
+                    "fact",
+                    "decision",
+                    "pattern",
+                    "task_summary",
+                    "correction",
+                    "relationship",
+                ],
+            ),
+        ],
+        timeout=30,
+        **common,
+    )
+
+    recall_memory = ToolDefinition(
+        name=TOOL_RECALL_LONG_TERM_MEMORY,
+        description=(
+            "Recall durable memory saved for this user and agent. Use this "
+            "when the user asks what you remember, references previous "
+            "preferences or constraints, or the answer may depend on stable "
+            "memory from earlier turns."
+        ),
+        parameters=[
+            ToolParameter(
+                name="query",
+                type="string",
+                description="The memory recall query.",
+                required=True,
+            ),
+            ToolParameter(
+                name="limit",
+                type="integer",
+                description="Maximum memory records to return. Defaults to 5.",
+                required=False,
+            ),
+        ],
+        timeout=30,
+        **common,
+    )
+
+    tools = [search_kb, save_memory, recall_memory]
+    if allowed_tool_names:
+        return [tool for tool in tools if tool.name in allowed_tool_names]
+    return tools
+
+
+__all__ = [
+    "CONTEXT_TOOLS_BUILTIN_TYPE",
+    "CONTEXT_TOOLS_SEMANTIC_FAMILY",
+    "TOOL_RECALL_LONG_TERM_MEMORY",
+    "TOOL_SAVE_LONG_TERM_MEMORY",
+    "TOOL_SEARCH_AGENT_KNOWLEDGE_BASE",
+    "build_context_tool_definitions",
+]

--- a/backend/app/ai/engine/intent_domain_rules.py
+++ b/backend/app/ai/engine/intent_domain_rules.py
@@ -8,23 +8,14 @@ from typing import Any
 from app.ai.engine.intent_domain_rules_terms import (
     _CAPABILITY_QUERY_TERMS,
     _CAPABILITY_REFERENCE_TERMS,
-    _KNOWLEDGE_COURTESY_PREFIXES,
-    _KNOWLEDGE_DEFINITION_PATTERNS,
-    _KNOWLEDGE_FILLER_SUFFIXES,
-    _KNOWLEDGE_GENERIC_SUBJECTS,
-    _MEMORY_QUERY_HINT_TERMS,
-    _MEMORY_RECALL_TERMS,
-    _MEMORY_SAVE_TERMS,
     _NO_TOOL_REQUEST_TERMS,
     _TIME_TERMS,
 )
 from app.ai.engine.intent_signal_helpers import (
     _first_position,
     _IntentSignal,
-    _semantic_profile_position,
     _tool_families,
 )
-from app.ai.text_semantics import has_question_indicator
 from app.ai.tools.types import ToolDefinition
 
 _CN_LOCAL_TIME_RE = re.compile(r"(?:当前|现在)?[\u4e00-\u9fff]{1,12}(?:时间|时区)")
@@ -47,65 +38,6 @@ _TOOL_INVOCATION_ASSERTION_TOOL_TERMS = (
     "调用工具",
     "实际调用工具",
 )
-_MEMORY_SAVE_PHRASES = (
-    "写入长期记忆",
-    "写入记忆",
-    "写进长期记忆",
-    "写进记忆",
-    "写到长期记忆",
-    "写到记忆",
-)
-_MEMORY_CODEWORD_TERMS = ("代号", "暗号", "codeword", "codename")
-_MEMORY_RECALL_CONTEXT_TERMS = (
-    "之前",
-    "刚才",
-    "先前",
-    "还记得",
-    "告诉我",
-    "回答我",
-    "是什么",
-    "是啥",
-    "哪个",
-    "哪一个",
-    "what",
-    "which",
-    "recall",
-)
-_KNOWLEDGE_QUERY_PROFILE = (
-    "what is explain introduce tell me about knowledge base document policy definition",
-    "是什么 介绍一下 讲讲 说说 说明一下 科普一下 文档 资料 政策",
-)
-_EXPLICIT_KB_REFERENCE_RE = re.compile(
-    r"(?:知识库|knowledge base|\bkb\b)",
-    re.IGNORECASE,
-)
-_KNOWLEDGE_EXPLICIT_REFERENCE_TERMS = (
-    "根据",
-    "基于",
-    "结合",
-    "参考",
-    "引用",
-    "概括",
-    "总结",
-    "归纳",
-    "summarize",
-    "summary",
-    "based on",
-    "using",
-    "from the knowledge base",
-)
-_KNOWLEDGE_WEB_PREFIX_RE = re.compile(
-    r"^(?:联网|上网)?\s*(?:查一下|查下|搜索一下|搜索|搜一下|搜一搜|搜搜|look up|search(?: online)?)\s*",
-    re.IGNORECASE,
-)
-_GENERIC_KNOWLEDGE_QUESTION_PATTERNS = tuple(
-    re.compile(
-        rf"^{re.escape(subject)}\s*(?:是什么|是啥|是谁|what is|who is|tell me about)\b",
-        re.IGNORECASE,
-    )
-    for subject in _KNOWLEDGE_GENERIC_SUBJECTS
-)
-
 
 class IntentDomainRules:
     """Domain-focused intent classification helpers for tool routing."""
@@ -173,175 +105,6 @@ class IntentDomainRules:
 
         return -1
 
-    @staticmethod
-    def is_question_like_clause(lowered: str) -> bool:
-        if not lowered:
-            return False
-        return has_question_indicator(lowered) or any(
-            token in lowered for token in _MEMORY_QUERY_HINT_TERMS
-        )
-
-    @classmethod
-    def memory_save_position(cls, lowered: str) -> int:
-        positions = [
-            position
-            for position in (
-                _first_position(lowered, _MEMORY_SAVE_TERMS),
-                *[lowered.find(phrase) for phrase in _MEMORY_SAVE_PHRASES],
-            )
-            if position >= 0
-        ]
-        if positions:
-            return min(positions)
-        if "记住" in lowered and not cls.is_question_like_clause(lowered):
-            return lowered.find("记住")
-        if "记下来" in lowered and not cls.is_question_like_clause(lowered):
-            return lowered.find("记下来")
-        return -1
-
-    @classmethod
-    def memory_recall_position(cls, lowered: str) -> int:
-        if not lowered:
-            return -1
-        recall_terms = tuple(
-            term for term in _MEMORY_RECALL_TERMS if term not in _MEMORY_CODEWORD_TERMS
-        )
-        pos = _first_position(lowered, recall_terms)
-        if pos >= 0:
-            return pos
-        codeword_positions = [
-            lowered.find(term)
-            for term in _MEMORY_CODEWORD_TERMS
-            if lowered.find(term) >= 0
-        ]
-        if codeword_positions:
-            has_save_cues = any(
-                token in lowered
-                for token in (
-                    *_MEMORY_SAVE_PHRASES,
-                    "长期记忆",
-                    "记忆",
-                    "记住",
-                    "记下来",
-                    "保存",
-                    "存入",
-                    "写入",
-                    "写进",
-                    "写到",
-                )
-            )
-            question_like = cls.is_question_like_clause(lowered)
-            if (not has_save_cues or question_like) and (
-                question_like
-                or any(token in lowered for token in _MEMORY_RECALL_CONTEXT_TERMS)
-            ):
-                return min(codeword_positions)
-        if "记得" in lowered and cls.is_question_like_clause(lowered):
-            return lowered.find("记得")
-        if "记住" in lowered and cls.is_question_like_clause(lowered):
-            return lowered.find("记住")
-        return -1
-
-    @classmethod
-    def has_bound_kb(cls, capability_bundle: Any | None) -> bool:
-        sources = getattr(capability_bundle, "context_sources", None) or []
-        for source in sources:
-            kind = (
-                str(source.get("kind") or "").strip()
-                if isinstance(source, dict)
-                else str(getattr(source, "kind", "") or "").strip()
-            )
-            if kind == "knowledge_base":
-                return True
-        return False
-
-    @classmethod
-    def normalize_knowledge_subject(cls, subject: str) -> str:
-        normalized = re.sub(
-            r"\s+",
-            " ",
-            str(subject or "").strip(" \t\r\n，,。！？?；;：:"),
-        )
-        if not normalized:
-            return ""
-        changed = True
-        while changed and normalized:
-            changed = False
-            for prefix in _KNOWLEDGE_COURTESY_PREFIXES:
-                if normalized.startswith(prefix):
-                    normalized = normalized[len(prefix) :].strip()
-                    changed = True
-            for suffix in _KNOWLEDGE_FILLER_SUFFIXES:
-                if normalized.endswith(suffix):
-                    normalized = normalized[: -len(suffix)].strip()
-                    changed = True
-        return normalized
-
-    @classmethod
-    def definition_like_knowledge_query_position(cls, clause: str) -> int:
-        text = re.sub(r"\s+", " ", str(clause or "").strip())
-        if not text:
-            return -1
-        lowered = text.lower()
-        for pattern in _KNOWLEDGE_DEFINITION_PATTERNS:
-            match = pattern.match(text)
-            if not match:
-                continue
-            subject = cls.normalize_knowledge_subject(match.group("subject"))
-            subject_lowered = subject.lower()
-            if (
-                not subject_lowered
-                or len(subject_lowered) <= 1
-                or subject_lowered in _KNOWLEDGE_GENERIC_SUBJECTS
-            ):
-                continue
-            position = lowered.find(subject_lowered)
-            return position if position >= 0 else 0
-        return -1
-
-    @classmethod
-    def knowledge_query_position(cls, clause: str) -> int:
-        position = cls.definition_like_knowledge_query_position(clause)
-        if position >= 0:
-            return position
-
-        lowered = str(clause or "").strip().lower()
-        kb_reference = _EXPLICIT_KB_REFERENCE_RE.search(lowered)
-        if kb_reference and (
-            any(term in lowered for term in _KNOWLEDGE_EXPLICIT_REFERENCE_TERMS)
-            or _semantic_profile_position(
-                lowered,
-                _KNOWLEDGE_QUERY_PROFILE,
-                min_score=1,
-            )
-            >= 0
-        ):
-            return kb_reference.start()
-
-        cleaned = _KNOWLEDGE_WEB_PREFIX_RE.sub("", str(clause or "").strip())
-        if cleaned != str(clause or "").strip():
-            position = cls.definition_like_knowledge_query_position(cleaned)
-            if position >= 0:
-                lowered_original = str(clause or "").strip().lower()
-                lowered_cleaned = cleaned.lower()
-                matched = lowered_cleaned[position:]
-                mapped = lowered_original.find(matched)
-                return mapped if mapped >= 0 else position
-
-        if not lowered or not cls.is_question_like_clause(lowered):
-            return -1
-        normalized_question = re.sub(r"[\s？?!.。]+", "", lowered)
-        if any(
-            pattern.match(normalized_question)
-            for pattern in _GENERIC_KNOWLEDGE_QUESTION_PATTERNS
-        ):
-            return -1
-        return _semantic_profile_position(
-            lowered,
-            _KNOWLEDGE_QUERY_PROFILE,
-            min_score=2,
-        )
-
     @classmethod
     def detect_domain_signals(
         cls,
@@ -353,7 +116,7 @@ class IntentDomainRules:
         capability_bundle: Any | None,
         continuation_context: Any | None,
     ) -> list[_IntentSignal]:
-        _ = continuation_context
+        _ = capability_bundle, continuation_context
         lowered = clause.lower()
         tools_forbidden = cls.explicitly_forbids_tool_usage(lowered)
         if cls.looks_like_capability_self_report(lowered):
@@ -364,32 +127,9 @@ class IntentDomainRules:
         families = _tool_families(tools, input_variables)
         signals: list[_IntentSignal] = []
 
-        # SHORTCIRCUIT: memory recall/save is explicit and should bypass semantic routing.
-        memory_recall_position = cls.memory_recall_position(lowered)
-        if memory_recall_position >= 0:
-            signals.append(
-                _IntentSignal(
-                    "memory_recall",
-                    "memory",
-                    "memory_recall",
-                    offset + memory_recall_position,
-                    requires_tools=False,
-                    shortcircuit=True,
-                    metadata={"routing_mode": "deterministic_shortcircuit"},
-                )
-            )
-        elif (memory_save_position := cls.memory_save_position(lowered)) >= 0:
-            signals.append(
-                _IntentSignal(
-                    "memory_save",
-                    "memory",
-                    "memory_save",
-                    offset + memory_save_position,
-                    requires_tools=False,
-                    shortcircuit=True,
-                    metadata={"routing_mode": "deterministic_shortcircuit"},
-                )
-            )
+        # Memory and knowledge retrieval are exposed as system context tools.
+        # The LLM now decides whether to call them via function calling instead
+        # of this keyword planner synthesizing memory_* or knowledge_query intents.
 
         # SHORTCIRCUIT: direct clock/date prompts should not depend on broader semantics.
         if "time_ops" in families:
@@ -403,29 +143,6 @@ class IntentDomainRules:
                         offset + position,
                         shortcircuit=True,
                         metadata={"routing_mode": "deterministic_shortcircuit"},
-                    )
-                )
-
-        knowledge_query_position = (
-            cls.knowledge_query_position(clause)
-            if cls.has_bound_kb(capability_bundle)
-            else -1
-        )
-
-        if cls.has_bound_kb(capability_bundle):
-            has_memory_signal = any(
-                signal.kind in {"memory_save", "memory_recall"} for signal in signals
-            )
-            position = knowledge_query_position
-            if position >= 0 and not has_memory_signal:
-                signals.append(
-                    _IntentSignal(
-                        "knowledge_query",
-                        "none",
-                        "knowledge_query",
-                        offset + position,
-                        requires_tools=False,
-                        metadata={"routing_mode": "structured_semantic"},
                     )
                 )
 

--- a/backend/app/ai/engine/intent_domain_rules_terms.py
+++ b/backend/app/ai/engine/intent_domain_rules_terms.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import re
-
 _CAPABILITY_QUERY_TERMS = (
     "是否能",
     "能否",
@@ -61,110 +59,9 @@ _TIME_TERMS = (
     "what day is it",
     "what date is it",
 )
-_KNOWLEDGE_TERMS = ("知识库", "文档", "资料", "kb")
-_KNOWLEDGE_DEFINITION_PATTERNS = (
-    re.compile(
-        r"^(?:请|请问|帮我|麻烦|麻烦你|想知道|我想知道|告诉我|给我|能不能|可以)?(?P<subject>.+?)(?:是什么|是啥|是谁|是做什么的|做什么的|是干什么的)[？?]?$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"^(?:请|请问|帮我|麻烦|麻烦你|想知道|我想知道|告诉我|给我|能不能|可以)?(?:介绍一下|介绍下|讲讲|说说|科普一下|说明一下)(?P<subject>.+?)[？?]?$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"^(?:what is|who is|tell me about)\s+(?P<subject>.+?)[？?]?$",
-        re.IGNORECASE,
-    ),
-)
-_KNOWLEDGE_GENERIC_SUBJECTS = (
-    "这",
-    "这个",
-    "那个",
-    "它",
-    "他",
-    "她",
-    "ta",
-    "this",
-    "that",
-    "it",
-    "这玩意",
-    "这个东西",
-    "那个东西",
-)
-_KNOWLEDGE_COURTESY_PREFIXES = (
-    "请问",
-    "请",
-    "帮我",
-    "麻烦你",
-    "麻烦",
-    "我想知道",
-    "想知道",
-    "告诉我",
-    "给我",
-)
-_KNOWLEDGE_FILLER_SUFFIXES = (
-    "一下",
-    "下",
-    "呢",
-    "呀",
-    "啊",
-    "吧",
-)
-_MEMORY_SAVE_TERMS = (
-    "存入记忆",
-    "存入长期记忆",
-    "存到记忆",
-    "存到长期记忆",
-    "保存到记忆",
-    "保存到长期记忆",
-    "记住这个",
-    "记住这句",
-    "记住这条",
-    "帮我记住",
-    "请记住",
-    "把这个记下来",
-    "把这句记下来",
-    "记下来",
-    "记到记忆",
-    "记到长期记忆",
-    "remember this",
-    "save to memory",
-)
-_MEMORY_RECALL_TERMS = (
-    "你还记得",
-    "还记得我",
-    "刚才让你记住",
-    "之前让你记住",
-    "我刚才说的",
-    "回忆一下",
-    "代号",
-    "codename",
-    "remember",
-    "recall",
-)
-_MEMORY_QUERY_HINT_TERMS = (
-    "是什么",
-    "是啥",
-    "还记得",
-    "记得吗",
-    "记住了没",
-    "回忆",
-    "remember",
-    "recall",
-    "what",
-    "which",
-)
 __all__ = [
     "_CAPABILITY_QUERY_TERMS",
     "_CAPABILITY_REFERENCE_TERMS",
-    "_KNOWLEDGE_COURTESY_PREFIXES",
-    "_KNOWLEDGE_DEFINITION_PATTERNS",
-    "_KNOWLEDGE_FILLER_SUFFIXES",
-    "_KNOWLEDGE_GENERIC_SUBJECTS",
-    "_KNOWLEDGE_TERMS",
-    "_MEMORY_QUERY_HINT_TERMS",
-    "_MEMORY_RECALL_TERMS",
-    "_MEMORY_SAVE_TERMS",
     "_NO_TOOL_REQUEST_TERMS",
     "_TIME_TERMS",
 ]

--- a/backend/app/ai/engine/intent_planner.py
+++ b/backend/app/ai/engine/intent_planner.py
@@ -99,8 +99,6 @@ class _IntentPlannerOrchestrator:
             metadata: dict[str, Any] = dict(signal.metadata or {})
             allow_text_response = False
             cached_result = None
-            if signal.kind == "memory_save":
-                cached_result = "已记住。"
             order = len(plans) + 1
             plans.append(
                 IntentPlan(

--- a/backend/app/ai/engine/prepare_execution_tool_helpers.py
+++ b/backend/app/ai/engine/prepare_execution_tool_helpers.py
@@ -610,6 +610,7 @@ def plan_execution_tools(
                 user_query=user_query,
                 limit=limit,
             )
+            _from_default_context_fallback = False
             if not tool_candidates:
                 tool_candidates = _pending_confirmation_tools(
                     all_tools=all_tools,
@@ -621,42 +622,56 @@ def plan_execution_tools(
                     all_tools=all_tools,
                     limit=limit,
                 )
+                if tool_candidates:
+                    _from_default_context_fallback = True
             candidate_tool_names = [tool.name for tool in tool_candidates]
             if tool_candidates:
-                promoted_intent = _promote_direct_reply_metadata_intent(
-                    intent_plan=intent_plan,
-                    tool_candidates=tool_candidates,
-                    input_variables=request.input_variables,
-                )
-                if promoted_intent is not None:
-                    actionable_intents = [promoted_intent]
-                    explicit_requested_families = (
-                        _ordered_requested_families_from_intents_impl(
-                            intents=intent_plan
-                        )
-                    )
-                    execution_path = PathSelector.select(intent_plan)
-                    execution_budget = BudgetGuard.build_default(
-                        execution_path,
-                        intent_count=len(intent_plan),
-                    )
-                    intent_flags = _intent_plan_gating_flags_impl(
-                        intent_plan,
-                        request=request,
-                    )
-                else:
-                    explicit_request = _looks_like_explicit_tool_request(user_query)
+                # Default context-tools fallback must NOT be promoted to
+                # required; keep them as optional (mode="auto") so the model
+                # can freely choose plain text for greetings / chit-chat.
+                if _from_default_context_fallback:
                     tool_use_policy = ToolUsePolicy(
                         family="none",
-                        mode="required" if explicit_request else "auto",
+                        mode="auto",
                         allowed_tool_names=list(candidate_tool_names),
-                        retry_on_contract_breach=explicit_request,
-                        reason=(
-                            "direct_reply_explicit_tool_request"
-                            if explicit_request
-                            else "direct_reply_discoverable_tools"
-                        ),
+                        retry_on_contract_breach=False,
+                        reason="direct_reply_optional_context_tools",
                     )
+                else:
+                    promoted_intent = _promote_direct_reply_metadata_intent(
+                        intent_plan=intent_plan,
+                        tool_candidates=tool_candidates,
+                        input_variables=request.input_variables,
+                    )
+                    if promoted_intent is not None:
+                        actionable_intents = [promoted_intent]
+                        explicit_requested_families = (
+                            _ordered_requested_families_from_intents_impl(
+                                intents=intent_plan
+                            )
+                        )
+                        execution_path = PathSelector.select(intent_plan)
+                        execution_budget = BudgetGuard.build_default(
+                            execution_path,
+                            intent_count=len(intent_plan),
+                        )
+                        intent_flags = _intent_plan_gating_flags_impl(
+                            intent_plan,
+                            request=request,
+                        )
+                    else:
+                        explicit_request = _looks_like_explicit_tool_request(user_query)
+                        tool_use_policy = ToolUsePolicy(
+                            family="none",
+                            mode="required" if explicit_request else "auto",
+                            allowed_tool_names=list(candidate_tool_names),
+                            retry_on_contract_breach=explicit_request,
+                            reason=(
+                                "direct_reply_explicit_tool_request"
+                                if explicit_request
+                                else "direct_reply_discoverable_tools"
+                            ),
+                        )
         if not tool_candidates and actionable_intents:
             fallback_allowed_names = _allowed_tool_names_for_families_impl(
                 explicit_requested_families,

--- a/backend/app/ai/engine/prepare_execution_tool_helpers.py
+++ b/backend/app/ai/engine/prepare_execution_tool_helpers.py
@@ -249,6 +249,21 @@ def _direct_reply_discoverable_tools(
     return selected
 
 
+def _default_context_tools_for_direct_reply(
+    *,
+    all_tools: list[ToolDefinition],
+    limit: int,
+) -> list[ToolDefinition]:
+    if limit <= 0:
+        return []
+    selected = [
+        tool
+        for tool in all_tools
+        if normalize_semantic_family(tool_semantic_family(tool)) == "context_tools"
+    ]
+    return selected[:limit]
+
+
 def _pending_confirmation_tools(
     *,
     all_tools: list[ToolDefinition],
@@ -600,6 +615,11 @@ def plan_execution_tools(
                     all_tools=all_tools,
                     messages=messages,
                     input_variables=request.input_variables,
+                )
+            if not tool_candidates:
+                tool_candidates = _default_context_tools_for_direct_reply(
+                    all_tools=all_tools,
+                    limit=limit,
                 )
             candidate_tool_names = [tool.name for tool in tool_candidates]
             if tool_candidates:

--- a/backend/app/ai/engine/system_prompt_capability_decisions.py
+++ b/backend/app/ai/engine/system_prompt_capability_decisions.py
@@ -65,7 +65,12 @@ def resolve_capability_injection_decision(
         or (
             capability_summary_injected
             and "knowledge_base" in active_context_source_kinds
-            and bool(intent_flags.get("has_knowledge_intent"))
+            and bool(
+                intent_flags.get(
+                    "has_bound_kb",
+                    intent_flags.get("has_knowledge_intent"),
+                )
+            )
         )
     )
     decision["memory_injected"] = bool(

--- a/backend/app/ai/engine/system_prompt_intent_helpers.py
+++ b/backend/app/ai/engine/system_prompt_intent_helpers.py
@@ -109,6 +109,8 @@ def intent_plan_gating_flags(
     return {
         "all_shortcircuit": bool(flags.all_shortcircuit),
         "has_knowledge_intent": bool(flags.has_knowledge_intent),
+        "has_bound_kb": bool(flags.has_bound_kb),
+        "should_skip_bound_kb_rag": bool(flags.should_skip_bound_kb_rag),
         "has_memory_intent": bool(flags.has_memory_intent),
         "memory_context_enabled": bool(flags.memory_context_enabled),
         "session_memory_runtime_enabled": bool(flags.session_memory_runtime_enabled),

--- a/backend/app/ai/engine/tool_router.py
+++ b/backend/app/ai/engine/tool_router.py
@@ -63,9 +63,6 @@ class ToolRouter:
                 register(intent, ["get_current_time"])
                 continue
 
-            if intent.kind == "knowledge_query":
-                register(intent, [])
-
         if (
             budget.max_candidate_tools > 0
             and len(candidate_names) > budget.max_candidate_tools

--- a/backend/app/ai/prompt_contracts/resources/turn_capabilities.md
+++ b/backend/app/ai/prompt_contracts/resources/turn_capabilities.md
@@ -21,7 +21,7 @@ This JSON describes the current turn's bound knowledge bases and retrieval statu
 Bound knowledge bases are available context providers, not proof that this turn has cited their content.
 Only retrieval.status="injected" means concrete knowledge-base snippets were injected for this turn.
 If retrieval.status="attempted_no_results", say that the knowledge base is bound but no matching snippets were found; do not claim to have read or cited missing content.
-If retrieval.status is "skipped_not_knowledge_intent" or "no_effective_knowledge_base", do not invent knowledge-base evidence.
+If retrieval.status is "skipped_shortcircuit" or "no_effective_knowledge_base", do not invent knowledge-base evidence.
 knowledge_context={{ knowledge_context | prompt_json }}
 [/RUNTIME KNOWLEDGE CONTEXT METADATA]
 {% endif %}

--- a/backend/app/ai/prompt_contracts/resources/turn_capabilities.md
+++ b/backend/app/ai/prompt_contracts/resources/turn_capabilities.md
@@ -21,7 +21,7 @@ This JSON describes the current turn's bound knowledge bases and retrieval statu
 Bound knowledge bases are available context providers, not proof that this turn has cited their content.
 Only retrieval.status="injected" means concrete knowledge-base snippets were injected for this turn.
 If retrieval.status="attempted_no_results", say that the knowledge base is bound but no matching snippets were found; do not claim to have read or cited missing content.
-If retrieval.status is "skipped_shortcircuit" or "no_effective_knowledge_base", do not invent knowledge-base evidence.
+If retrieval.status is "skipped_tool_managed" or "no_effective_knowledge_base", do not invent knowledge-base evidence.
 knowledge_context={{ knowledge_context | prompt_json }}
 [/RUNTIME KNOWLEDGE CONTEXT METADATA]
 {% endif %}

--- a/backend/app/ai/runtime/context_assembler.py
+++ b/backend/app/ai/runtime/context_assembler.py
@@ -187,7 +187,7 @@ class ContextAssembler:
         )
 
         provider_names = ["skills"]
-        if not flags.all_shortcircuit and flags.has_knowledge_intent:
+        if flags.has_bound_kb and not flags.should_skip_bound_kb_rag:
             provider_names.append("knowledge_base")
         if memory_policy.memory_context_enabled or has_session_memory_context:
             provider_names.append("memory")

--- a/backend/app/ai/runtime/context_capability_bridge.py
+++ b/backend/app/ai/runtime/context_capability_bridge.py
@@ -225,9 +225,11 @@ class DefaultContextCapabilityBridge(ContextCapabilityBridge):
             capability_reporting_query = is_capability_reporting_query(
                 _last_user_text(request),
             )
+            has_bound_kb = bool(
+                intent_flags.get("has_bound_kb") or knowledge_base_ids
+            )
             include_kb_context = bool(
-                (intent_flags.get("has_knowledge_intent") or capability_reporting_query)
-                and knowledge_base_ids
+                (has_bound_kb or capability_reporting_query) and knowledge_base_ids
             )
             kb_bindings: list[dict[str, Any]] = []
             if include_kb_context:
@@ -255,7 +257,7 @@ class DefaultContextCapabilityBridge(ContextCapabilityBridge):
                     rag_matched_chunk_count=rag_matched_chunk_count,
                 )
             if not awareness.enabled or (
-                intent_flags.get("all_shortcircuit", False)
+                intent_flags.get("should_skip_bound_kb_rag", False)
                 and not capability_reporting_query
             ):
                 return awareness
@@ -272,8 +274,7 @@ class DefaultContextCapabilityBridge(ContextCapabilityBridge):
                 )
 
             include_kb_awareness = bool(
-                (intent_flags.get("has_knowledge_intent") or capability_reporting_query)
-                and knowledge_base_ids
+                (has_bound_kb or capability_reporting_query) and knowledge_base_ids
             )
             if include_kb_awareness:
                 kb_description = capability_builder.build_knowledge_base_descriptions(

--- a/backend/app/ai/skills/resolver.py
+++ b/backend/app/ai/skills/resolver.py
@@ -307,14 +307,19 @@ def _preview_tool_names_for_skill(
     if skill_type == "builtin":
         tools_config = config.get("tools")
         if isinstance(tools_config, list):
+            tool_names: list[str] = []
+            for tool_cfg in tools_config:
+                if isinstance(tool_cfg, str):
+                    raw_tool_name = tool_cfg
+                elif isinstance(tool_cfg, dict):
+                    raw_tool_name = tool_cfg.get("name") or ""
+                else:
+                    continue
+                tool_name = str(raw_tool_name or "").strip()
+                if tool_name and tool_name not in _RUNTIME_BUILTIN_TOOL_NAMES:
+                    tool_names.append(tool_name)
             return _live_runtime_references(
-                [
-                    str((tool_cfg or {}).get("name") or "").strip()
-                    for tool_cfg in tools_config
-                    if str((tool_cfg or {}).get("name") or "").strip()
-                    and str((tool_cfg or {}).get("name") or "").strip()
-                    not in _RUNTIME_BUILTIN_TOOL_NAMES
-                ]
+                tool_names
             )
         tool_name = str(getattr(skill, "name", "") or "").strip()
         if tool_name in _RUNTIME_BUILTIN_TOOL_NAMES:

--- a/backend/app/ai/skills/resolver_parts/builtin.py
+++ b/backend/app/ai/skills/resolver_parts/builtin.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from app.ai.context_tools.tools import build_context_tool_definitions
 from app.ai.prompt_contracts import render_prompt_contract
 from app.ai.runtime.types import CapabilityDescriptor
 from app.ai.tools.types import ToolDefinition, ToolParameter
 from app.enums.agent import ToolTypeEnum
 
+CONTEXT_BUILTIN_TOOL_NAMES = (
+    "search_agent_knowledge_base",
+    "save_long_term_memory",
+    "recall_long_term_memory",
+)
 BASELINE_RUNTIME_BUILTINS = ("get_current_time",)
 RUNTIME_BUILTINS = frozenset(BASELINE_RUNTIME_BUILTINS)
 
@@ -79,7 +85,7 @@ def build_baseline_builtin_tool(
     return tool
 
 
-def inject_baseline_runtime_builtins(
+def inject_time_runtime_builtin(
     *,
     result: Any,
     apply_tool_semantics: Callable[[ToolDefinition], None],
@@ -91,7 +97,7 @@ def inject_baseline_runtime_builtins(
         if str(descriptor.kind or "").strip() == "capability_pack"
     }
 
-    for tool_name in BASELINE_RUNTIME_BUILTINS:
+    for tool_name in ("get_current_time",):
         if tool_name in existing_tool_names:
             continue
 
@@ -126,13 +132,24 @@ def inject_baseline_runtime_builtins(
         existing_tool_names.add(tool.name)
 
 
+def inject_baseline_runtime_builtins(
+    *,
+    result: Any,
+    apply_tool_semantics: Callable[[ToolDefinition], None],
+) -> None:
+    inject_time_runtime_builtin(
+        result=result,
+        apply_tool_semantics=apply_tool_semantics,
+    )
+
+
 def build_time_only_runtime_result(
     *,
     result_factory: Callable[[], Any],
     apply_tool_semantics: Callable[[ToolDefinition], None],
 ) -> Any:
     result = result_factory()
-    inject_baseline_runtime_builtins(
+    inject_time_runtime_builtin(
         result=result,
         apply_tool_semantics=apply_tool_semantics,
     )
@@ -155,13 +172,22 @@ def resolve_builtin(
             result.tools.append(tool)
         return
 
+    if str(config.get("builtin_type") or "").strip() == "context_tools":
+        for tool in build_context_tool_definitions(skill=skill, config=config):
+            result.tools.append(tool)
+        return
+
     tools_config = config.get("tools")
     tool_type_override = config.get("tool_type", ToolTypeEnum.BUILTIN.value)
 
     if tools_config and isinstance(tools_config, list):
         for tool_cfg in tools_config:
             tool_name = tool_cfg.get("name", "")
-            if not tool_name or str(tool_name).strip() in RUNTIME_BUILTINS:
+            normalized_tool_name = str(tool_name).strip()
+            if not normalized_tool_name or normalized_tool_name in {
+                *RUNTIME_BUILTINS,
+                *CONTEXT_BUILTIN_TOOL_NAMES,
+            }:
                 continue
             tool_params = build_params_from_schema(tool_cfg.get("parameters"))
             description = augment_builtin_tool_description(

--- a/backend/app/ai/tools/executors/context_tool_executor.py
+++ b/backend/app/ai/tools/executors/context_tool_executor.py
@@ -1,0 +1,347 @@
+"""
+Executor for system context tools.
+
+The executor runs knowledge-base search and long-term memory operations in the
+current agent/user/tenant context. It intentionally does not share the
+internal-api executor because these tools are not management-console API calls.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from app.ai.context_tools.tools import (
+    TOOL_RECALL_LONG_TERM_MEMORY,
+    TOOL_SAVE_LONG_TERM_MEMORY,
+    TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+)
+from app.ai.rag_injector import load_agent_kb_bindings
+from app.ai.tools.executors.base import BaseToolExecutor
+from app.ai.tools.types import ExecutionContext, ToolDefinition, ToolResult
+from app.core.logging import LogManager
+from app.enums.memory import MemorySourceKindEnum, MemoryTypeEnum
+
+logger = LogManager.get_logger("ai.tool.context")
+
+
+def _json_output(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def _normalize_limit(value: Any, *, default: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(1, min(parsed, maximum))
+
+
+def _normalize_platform_tenant_id(value: int | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _memory_record_payload(record: Any) -> dict[str, Any]:
+    return {
+        "id": getattr(record, "id", None),
+        "memory_type": getattr(record, "memory_type", None),
+        "content": getattr(record, "summary", None)
+        or getattr(record, "content", None),
+        "importance": getattr(record, "importance", None),
+        "confidence": getattr(record, "confidence", None),
+        "updated_at": getattr(record, "updated_at", None),
+    }
+
+
+class ContextToolExecutor(BaseToolExecutor):
+    async def validate(
+        self,
+        definition: ToolDefinition,
+        arguments: dict[str, Any],
+    ) -> bool:
+        _ = definition, arguments
+        return True
+
+    async def execute(
+        self,
+        definition: ToolDefinition,
+        tool_call_id: str,
+        arguments: dict[str, Any],
+        context: ExecutionContext | None = None,
+    ) -> ToolResult:
+        start = time.perf_counter()
+        name = definition.name
+        if context is None or context.db is None:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Context tools require an active database-backed conversation.",
+                name=name,
+            )
+
+        try:
+            if name == TOOL_SEARCH_AGENT_KNOWLEDGE_BASE:
+                result = await self._search_agent_knowledge_base(
+                    tool_call_id,
+                    arguments,
+                    context,
+                )
+            elif name == TOOL_SAVE_LONG_TERM_MEMORY:
+                result = await self._save_long_term_memory(
+                    tool_call_id,
+                    arguments,
+                    context,
+                )
+            elif name == TOOL_RECALL_LONG_TERM_MEMORY:
+                result = await self._recall_long_term_memory(
+                    tool_call_id,
+                    arguments,
+                    context,
+                )
+            else:
+                result = ToolResult.error_result(
+                    tool_call_id,
+                    f"Unknown context tool: {name}",
+                    name=name,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Context tool {} failed: {}", name, exc, exc_info=True)
+            result = ToolResult.error_result(
+                tool_call_id,
+                f"Context tool failed: {exc}",
+                name=name,
+            )
+
+        result.duration_ms = int((time.perf_counter() - start) * 1000)
+        return result
+
+    async def _search_agent_knowledge_base(
+        self,
+        tool_call_id: str,
+        arguments: dict[str, Any],
+        context: ExecutionContext,
+    ) -> ToolResult:
+        query = str(arguments.get("query") or "").strip()
+        if not query:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Argument 'query' is required.",
+                name=TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+            )
+
+        kb_ids, kb_weights = await load_agent_kb_bindings(
+            context.db,
+            context.agent_id,
+            context.tenant_id,
+        )
+        if not kb_ids:
+            return ToolResult(
+                tool_call_id=tool_call_id,
+                name=TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+                success=True,
+                output=_json_output(
+                    {
+                        "status": "no_effective_knowledge_base",
+                        "sources": [],
+                        "snippets": [],
+                    }
+                ),
+                summary="No bound knowledge base",
+            )
+
+        from app.ai.rag.retriever import HybridRetriever
+        from app.repositories.ai.knowledge_base_repository import (
+            AdminKnowledgeBaseRepository,
+            KnowledgeBaseRepository,
+        )
+
+        effective_tenant_id = _normalize_platform_tenant_id(context.tenant_id)
+        kb_repo = (
+            KnowledgeBaseRepository(context.db, tenant_id=effective_tenant_id)
+            if effective_tenant_id is not None
+            else AdminKnowledgeBaseRepository(context.db)
+        )
+        validated_kbs = []
+        validated_kb_ids: list[int] = []
+        for kb_id in kb_ids:
+            kb = await kb_repo.get_by_id(kb_id)
+            if kb is None:
+                continue
+            validated_kbs.append(kb)
+            validated_kb_ids.append(int(kb_id))
+
+        if not validated_kb_ids:
+            return ToolResult(
+                tool_call_id=tool_call_id,
+                name=TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+                success=True,
+                output=_json_output(
+                    {
+                        "status": "no_accessible_knowledge_base",
+                        "sources": [],
+                        "snippets": [],
+                    }
+                ),
+                summary="No accessible knowledge base",
+            )
+
+        rag_config = {}
+        agent = context.agent
+        if agent is not None and isinstance(getattr(agent, "rag_config", None), dict):
+            rag_config = dict(agent.rag_config or {})
+        top_k = _normalize_limit(
+            arguments.get("top_k"),
+            default=int(rag_config.get("top_k", 5) or 5),
+            maximum=20,
+        )
+        retriever = HybridRetriever(context.db, effective_tenant_id)
+        chunks = await retriever.search(
+            query=query,
+            top_k=top_k,
+            score_threshold=rag_config.get("score_threshold", 0.5),
+            search_mode=rag_config.get("search_mode", "hybrid"),
+            kb_ids=validated_kb_ids,
+            rewrite_strategy=rag_config.get("rewrite_strategy", "none"),
+            reranker_enabled=rag_config.get("reranker_enabled", False),
+            knowledge_bases=validated_kbs,
+            kb_weights=kb_weights,
+        )
+        snippets = [
+            {
+                "chunk_id": getattr(chunk, "chunk_id", None),
+                "knowledge_base_id": getattr(chunk, "knowledge_base_id", None),
+                "document_id": getattr(chunk, "document_id", None),
+                "document_name": getattr(chunk, "document_name", None),
+                "chunk_index": getattr(chunk, "chunk_index", None),
+                "score": getattr(chunk, "score", None),
+                "content": getattr(chunk, "content", None),
+                "recall_sources": list(getattr(chunk, "recall_sources", []) or []),
+            }
+            for chunk in chunks
+        ]
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            name=TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+            success=True,
+            output=_json_output(
+                {
+                    "status": "ok" if snippets else "no_results",
+                    "query": query,
+                    "knowledge_base_ids": validated_kb_ids,
+                    "snippets": snippets,
+                }
+            ),
+            summary=f"{len(snippets)} knowledge snippets matched",
+        )
+
+    async def _save_long_term_memory(
+        self,
+        tool_call_id: str,
+        arguments: dict[str, Any],
+        context: ExecutionContext,
+    ) -> ToolResult:
+        if not context.user_id:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Long-term memory requires an authenticated user.",
+                name=TOOL_SAVE_LONG_TERM_MEMORY,
+            )
+        content = str(arguments.get("content") or "").strip()
+        if not content:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Argument 'content' is required.",
+                name=TOOL_SAVE_LONG_TERM_MEMORY,
+            )
+        memory_type = str(arguments.get("memory_type") or "").strip()
+        if memory_type not in set(MemoryTypeEnum.values()):
+            memory_type = MemoryTypeEnum.FACT.value
+
+        from app.services.ai.long_term_memory_provider import (
+            get_long_term_memory_provider,
+        )
+
+        provider = get_long_term_memory_provider(
+            db=context.db,
+            tenant_id=context.tenant_id,
+        )
+        records = await provider.capture(
+            agent_id=context.agent_id,
+            user_id=context.user_id,
+            source_kind=MemorySourceKindEnum.CONVERSATION_TURN.value,
+            source_ref=str(context.conversation_id or "") or None,
+            items_by_type={memory_type: [content]},
+        )
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            name=TOOL_SAVE_LONG_TERM_MEMORY,
+            success=True,
+            output=_json_output(
+                {
+                    "status": "saved",
+                    "count": len(records),
+                    "memory_type": memory_type,
+                    "records": [_memory_record_payload(record) for record in records],
+                }
+            ),
+            summary=f"Saved {len(records)} memory record(s)",
+        )
+
+    async def _recall_long_term_memory(
+        self,
+        tool_call_id: str,
+        arguments: dict[str, Any],
+        context: ExecutionContext,
+    ) -> ToolResult:
+        if not context.user_id:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Long-term memory requires an authenticated user.",
+                name=TOOL_RECALL_LONG_TERM_MEMORY,
+            )
+        query = str(arguments.get("query") or "").strip()
+        if not query:
+            return ToolResult.error_result(
+                tool_call_id,
+                "Argument 'query' is required.",
+                name=TOOL_RECALL_LONG_TERM_MEMORY,
+            )
+        limit = _normalize_limit(arguments.get("limit"), default=5, maximum=20)
+
+        from app.services.ai.long_term_memory_provider import (
+            get_long_term_memory_provider,
+        )
+
+        provider = get_long_term_memory_provider(
+            db=context.db,
+            tenant_id=context.tenant_id,
+        )
+        records = await provider.recall(
+            agent_id=context.agent_id,
+            user_id=context.user_id,
+            query_text=query,
+            limit=limit,
+        )
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            name=TOOL_RECALL_LONG_TERM_MEMORY,
+            success=True,
+            output=_json_output(
+                {
+                    "status": "ok",
+                    "query": query,
+                    "count": len(records),
+                    "records": [_memory_record_payload(record) for record in records],
+                }
+            ),
+            summary=f"Recalled {len(records)} memory record(s)",
+        )
+
+
+__all__ = ["ContextToolExecutor"]

--- a/backend/app/ai/tools/sandbox.py
+++ b/backend/app/ai/tools/sandbox.py
@@ -168,6 +168,10 @@ class ToolSandbox:
         from app.ai.tools.executors.internal_api_executor import InternalApiExecutor
 
         self._executors[ToolTypeEnum.INTERNAL_API.value] = InternalApiExecutor()
+        # Context tool executor (agent KB + long-term memory) / 上下文工具执行器
+        from app.ai.tools.executors.context_tool_executor import ContextToolExecutor
+
+        self._executors[ToolTypeEnum.CONTEXT_TOOL.value] = ContextToolExecutor()
 
     def get_executor(self, tool_type: str) -> BaseToolExecutor | None:
         """Get executor for specified type / 获取指定类型的执行器"""
@@ -377,6 +381,7 @@ class ToolSandbox:
                 and self._runtime_model_info.get("model_code") is not None
                 else None
             ),
+            agent=self._agent,
         )
 
         # 5.5 Executor-level parameter validation / 执行器级参数校验

--- a/backend/app/ai/tools/semantic_defaults.py
+++ b/backend/app/ai/tools/semantic_defaults.py
@@ -27,6 +27,19 @@ FAMILY_HINT_TAGS: dict[str, tuple[str, ...]] = {
         "current time",
         "current date",
     ),
+    "context_tools": (
+        "知识库",
+        "文档",
+        "资料",
+        "检索",
+        "记忆",
+        "记住",
+        "回忆",
+        "knowledge base",
+        "memory",
+        "remember",
+        "recall",
+    ),
 }
 
 # Tags omitted from explicit-request hints (optimizer): slightly shorter / less “broad” cues than full FAMILY_HINT_TAGS.
@@ -71,6 +84,12 @@ def tool_family_from_name(
         return "none"
     if normalized == "get_current_time":
         return "time_ops"
+    if normalized in {
+        "search_agent_knowledge_base",
+        "save_long_term_memory",
+        "recall_long_term_memory",
+    }:
+        return "context_tools"
     return "none"
 
 

--- a/backend/app/ai/tools/types.py
+++ b/backend/app/ai/tools/types.py
@@ -241,6 +241,7 @@ class ExecutionContext:
     runtime_model_id: int | None = None
     runtime_model_name: str | None = None
     runtime_model_code: str | None = None
+    agent: Any | None = None
     tool_timeout_seconds: float | None = None
     tool_started_monotonic: float | None = None
     tool_deadline_monotonic: float | None = None

--- a/backend/app/enums/agent.py
+++ b/backend/app/enums/agent.py
@@ -77,6 +77,8 @@ class ToolTypeEnum(LabeledStrEnum):
     HTTP = ("http", "enum.agent.tool_type.http")
     EMAIL = ("email", "enum.agent.tool_type.email")
     CODE_EXECUTION = ("code_execution", "enum.agent.tool_type.code_execution")
+    # 智能体上下文工具（知识库检索、长期记忆读写）/ Agent context tools
+    CONTEXT_TOOL = ("context_tool", "enum.agent.tool_type.context_tool")
     # 内部 API 自调用（运营 Copilot 元工具）/ Internal API self-call (copilot meta-tools)
     INTERNAL_API = ("internal_api", "enum.agent.tool_type.internal_api")
 

--- a/backend/app/repositories/ai/skill_repository.py
+++ b/backend/app/repositories/ai/skill_repository.py
@@ -42,14 +42,17 @@ class SkillRepository(TenantRepository[Skill]):
 
     async def get_by_id(self, id: int, include_deleted: bool = False) -> Skill | None:
         """根据 ID 获取技能，允许访问全局 + 已分配技能包下的技能 / Get skill by ID (global + assigned package)."""
-        instance = await BaseRepository.get_by_id(self, id, include_deleted)
+        stmt = select(Skill).options(selectinload(Skill.package)).where(Skill.id == id)
+        if not include_deleted:
+            stmt = stmt.where(Skill.is_deleted.is_(False))
+        result = await self.db.execute(stmt)
+        instance = result.scalar_one_or_none()
         if instance and hasattr(instance, "tenant_id"):
             if is_retired_skill_instance(instance):
                 return None
             if not self._is_skill_tenant_visible(instance):
                 return None
-            pkg = await self.db.get(SkillPackage, instance.package_id)
-            if not self._is_package_visible(pkg):
+            if not self._is_package_visible(instance.package):
                 return None
         return instance
 
@@ -120,15 +123,25 @@ class SkillRepository(TenantRepository[Skill]):
         include_deleted: bool = False,
     ) -> list[Skill]:
         """Get skills by IDs with tenant-visible package fallback."""
-        instances = await BaseRepository.get_by_ids(self, ids, include_deleted)
+        if not ids:
+            return []
+
+        stmt = (
+            select(Skill)
+            .options(selectinload(Skill.package))
+            .where(Skill.id.in_(ids))
+        )
+        if not include_deleted:
+            stmt = stmt.where(Skill.is_deleted.is_(False))
+        result = await self.db.execute(stmt)
+        instances = list(result.scalars().all())
         visible: list[Skill] = []
         for instance in instances:
             if is_retired_skill_instance(instance):
                 continue
             if not self._is_skill_tenant_visible(instance):
                 continue
-            pkg = await self.db.get(SkillPackage, instance.package_id)
-            if self._is_package_visible(pkg):
+            if self._is_package_visible(instance.package):
                 visible.append(instance)
         return visible
 
@@ -358,7 +371,11 @@ class AdminSkillRepository(BaseRepository[Skill]):
     model = Skill
 
     async def get_by_id(self, id: int, include_deleted: bool = False) -> Skill | None:
-        instance = await super().get_by_id(id, include_deleted)
+        stmt = select(Skill).options(selectinload(Skill.package)).where(Skill.id == id)
+        if not include_deleted:
+            stmt = stmt.where(Skill.is_deleted.is_(False))
+        result = await self.db.execute(stmt)
+        instance = result.scalar_one_or_none()
         if instance and is_retired_skill_instance(instance):
             return None
         return instance
@@ -368,7 +385,18 @@ class AdminSkillRepository(BaseRepository[Skill]):
         ids: list[int],
         include_deleted: bool = False,
     ) -> list[Skill]:
-        instances = await super().get_by_ids(ids, include_deleted)
+        if not ids:
+            return []
+
+        stmt = (
+            select(Skill)
+            .options(selectinload(Skill.package))
+            .where(Skill.id.in_(ids))
+        )
+        if not include_deleted:
+            stmt = stmt.where(Skill.is_deleted.is_(False))
+        result = await self.db.execute(stmt)
+        instances = list(result.scalars().all())
         return [item for item in instances if not is_retired_skill_instance(item)]
 
     async def query_list(

--- a/backend/app/services/system/system_agent_seed_service.py
+++ b/backend/app/services/system/system_agent_seed_service.py
@@ -21,7 +21,14 @@ from app.enums.agent import (
 from app.enums.common import ResourceScopeEnum
 from app.enums.skill import SkillSourceTypeEnum, SkillStatusEnum
 from app.exceptions import BusinessException
-from app.models.ai import Agent, AgentSkillGrant, AIModel, AIProvider, Skill, SkillPackage
+from app.models.ai import (
+    Agent,
+    AgentSkillGrant,
+    AIModel,
+    AIProvider,
+    Skill,
+    SkillPackage,
+)
 from app.models.system.agent_assignment import SystemAgentAssignment
 from app.repositories.system.system_agent_seed_repository import (
     SystemAgentSeedRepository,
@@ -30,6 +37,12 @@ from app.repositories.system.system_agent_seed_repository import (
 SKILL_PACKAGE_NAME = "运营 Copilot 技能包"
 SKILL_KEY = "internal_operations"
 SKILL_NAME = "内部操作元工具"
+
+CONTEXT_SKILL_PACKAGE_NAME = "智能体上下文技能包（内置）"
+CONTEXT_KB_SKILL_KEY = "agent_context_knowledge_search"
+CONTEXT_KB_SKILL_NAME = "知识库检索工具"
+CONTEXT_MEMORY_SKILL_KEY = "agent_context_memory_tools"
+CONTEXT_MEMORY_SKILL_NAME = "长期记忆读写工具"
 
 ADMIN_COPILOT_NAME = "平台运营 Copilot"
 TENANT_COPILOT_NAME = "企业运营 Copilot"
@@ -369,6 +382,144 @@ class SystemAgentSeedService:
         await self.db.refresh(skill)
         return skill
 
+    async def _ensure_context_tools_skill_package(self) -> SkillPackage:
+        package = await self.repo.get_platform_system_skill_package_by_name(
+            CONTEXT_SKILL_PACKAGE_NAME,
+            include_deleted=True,
+        )
+        payload = {
+            "tenant_id": None,
+            "name": CONTEXT_SKILL_PACKAGE_NAME,
+            "description": "内置智能体上下文工具：知识库检索与长期记忆读写。",
+            "avatar": None,
+            "is_recommended": False,
+            "source_plugin": None,
+            "is_system": True,
+            "valves_schema": None,
+            "valves_config": None,
+            "is_active": True,
+            "sort_order": 10,
+        }
+        if package is None:
+            return await self.repo.create_skill_package(payload)
+
+        if package.is_deleted:
+            package.restore()
+        for key, value in payload.items():
+            setattr(package, key, value)
+        await self.db.flush()
+        await self.db.refresh(package)
+        return package
+
+    async def _ensure_context_tool_skill(
+        self,
+        *,
+        package: SkillPackage,
+        key: str,
+        name: str,
+        description: str,
+        tools: list[str],
+        timeout: int,
+        sort_order: int,
+    ) -> Skill:
+        skill = await self.repo.get_platform_system_skill_by_key(
+            key,
+            include_deleted=True,
+        )
+        if skill is None:
+            conflicting_skill = await self.repo.get_any_skill_by_key(
+                key,
+                include_deleted=True,
+            )
+            if conflicting_skill is not None:
+                raise BusinessException(
+                    message=_("agent.error.system_skill_key_conflict").format(
+                        key=key,
+                    )
+                )
+            return await self.repo.create_skill(
+                {
+                    "tenant_id": None,
+                    "package_id": package.id,
+                    "name": name,
+                    "key": key,
+                    "description": description,
+                    "avatar": None,
+                    "type": "builtin",
+                    "source_type": SkillSourceTypeEnum.PLATFORM_BUILTIN.value,
+                    "source_ref": None,
+                    "skill_md": None,
+                    "version": "1.0.0",
+                    "status": SkillStatusEnum.ACTIVE.value,
+                    "is_readonly": True,
+                    "config": {"builtin_type": "context_tools", "tools": tools},
+                    "toolkit_content": None,
+                    "toolkit_meta": None,
+                    "input_schema": None,
+                    "output_schema": None,
+                    "is_system": True,
+                    "is_active": True,
+                    "sort_order": sort_order,
+                    "timeout": timeout,
+                }
+            )
+
+        if skill.is_deleted:
+            skill.restore()
+        skill.tenant_id = None
+        skill.package_id = package.id
+        skill.name = name
+        skill.key = key
+        skill.description = description
+        skill.avatar = None
+        skill.type = "builtin"
+        skill.source_type = SkillSourceTypeEnum.PLATFORM_BUILTIN.value
+        skill.source_ref = None
+        skill.skill_md = None
+        skill.version = "1.0.0"
+        skill.status = SkillStatusEnum.ACTIVE.value
+        skill.is_readonly = True
+        skill.config = {"builtin_type": "context_tools", "tools": tools}
+        skill.toolkit_content = None
+        skill.toolkit_meta = None
+        skill.input_schema = None
+        skill.output_schema = None
+        skill.is_system = True
+        skill.is_active = True
+        skill.sort_order = sort_order
+        skill.timeout = timeout
+        await self.db.flush()
+        await self.db.refresh(skill)
+        return skill
+
+    async def _ensure_context_tool_skills(self) -> tuple[SkillPackage, list[Skill]]:
+        package = await self._ensure_context_tools_skill_package()
+        kb_skill = await self._ensure_context_tool_skill(
+            package=package,
+            key=CONTEXT_KB_SKILL_KEY,
+            name=CONTEXT_KB_SKILL_NAME,
+            description=(
+                "检索当前智能体绑定的知识库，返回片段、来源与引用线索。"
+                "工具 schema 由代码定义。"
+            ),
+            tools=["search_agent_knowledge_base"],
+            timeout=45,
+            sort_order=0,
+        )
+        memory_skill = await self._ensure_context_tool_skill(
+            package=package,
+            key=CONTEXT_MEMORY_SKILL_KEY,
+            name=CONTEXT_MEMORY_SKILL_NAME,
+            description=(
+                "保存与召回当前用户在当前智能体下的长期记忆。"
+                "工具 schema 由代码定义。"
+            ),
+            tools=["save_long_term_memory", "recall_long_term_memory"],
+            timeout=30,
+            sort_order=1,
+        )
+        return package, [kb_skill, memory_skill]
+
     async def _ensure_agent(
         self,
         feature: SystemAgentSeedFeature,
@@ -600,6 +751,8 @@ class SystemAgentSeedService:
 
         package = await self._ensure_skill_package()
         skill = await self._ensure_skill(package)
+        context_package, context_skills = await self._ensure_context_tool_skills()
+        del context_package
 
         created_agents = 0
         updated_agents = 0
@@ -620,17 +773,18 @@ class SystemAgentSeedService:
             else:
                 updated_agents += 1
 
-            grant_before = await self.repo.get_agent_skill_grant(
-                agent_id=agent.id,
-                skill_id=skill.id,
-                include_deleted=True,
-            )
-            grant_was_deleted = bool(getattr(grant_before, "is_deleted", False))
-            await self._ensure_grant(agent, skill)
-            if grant_before is None or grant_was_deleted:
-                created_grants += 1
-            else:
-                updated_grants += 1
+            for grant_skill in [skill, *context_skills]:
+                grant_before = await self.repo.get_agent_skill_grant(
+                    agent_id=agent.id,
+                    skill_id=grant_skill.id,
+                    include_deleted=True,
+                )
+                grant_was_deleted = bool(getattr(grant_before, "is_deleted", False))
+                await self._ensure_grant(agent, grant_skill)
+                if grant_before is None or grant_was_deleted:
+                    created_grants += 1
+                else:
+                    updated_grants += 1
 
             assignment_before = await self.repo.get_global_assignment(
                 feature.feature_code,

--- a/backend/migrations/versions/20260612_0051_seed_context_tools_skill_package.py
+++ b/backend/migrations/versions/20260612_0051_seed_context_tools_skill_package.py
@@ -1,0 +1,195 @@
+"""seed system context tools skill package
+
+Creates a DB-visible system skill package for agent-bound knowledge-base search
+and long-term memory tools. Tool schemas remain code-defined and are expanded by
+the builtin skill resolver.
+
+Revision ID: 20260612_0051_context_tools
+Revises: 20260612_0050_multi_dim_embed
+Create Date: 2026-06-12 22:10:00.000000+08:00
+
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "20260612_0051_context_tools"
+down_revision: str | Sequence[str] | None = "20260612_0050_multi_dim_embed"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SKILL_PACKAGE_NAME = "智能体上下文技能包（内置）"
+KB_SKILL_KEY = "agent_context_knowledge_search"
+KB_SKILL_NAME = "知识库检索工具"
+MEMORY_SKILL_KEY = "agent_context_memory_tools"
+MEMORY_SKILL_NAME = "长期记忆读写工具"
+
+
+def _ensure_package(conn) -> int:
+    row = conn.execute(
+        text(
+            "SELECT id FROM skill_packages "
+            "WHERE name = :name AND tenant_id IS NULL AND is_deleted = false "
+            "ORDER BY id LIMIT 1"
+        ),
+        {"name": SKILL_PACKAGE_NAME},
+    ).fetchone()
+    if row:
+        pkg_id = row[0]
+        conn.execute(
+            text(
+                "UPDATE skill_packages "
+                "SET description = :description, is_system = true, "
+                "    is_active = true, updated_at = NOW() "
+                "WHERE id = :id"
+            ),
+            {
+                "id": pkg_id,
+                "description": "内置智能体上下文工具：知识库检索与长期记忆读写。",
+            },
+        )
+        return int(pkg_id)
+
+    return int(
+        conn.execute(
+            text(
+                "INSERT INTO skill_packages "
+                "(tenant_id, name, description, is_recommended, is_system, "
+                " is_active, sort_order, created_at, updated_at, is_deleted) "
+                "VALUES "
+                "(NULL, :name, :description, false, true, "
+                " true, 10, NOW(), NOW(), false) "
+                "RETURNING id"
+            ),
+            {
+                "name": SKILL_PACKAGE_NAME,
+                "description": "内置智能体上下文工具：知识库检索与长期记忆读写。",
+            },
+        ).fetchone()[0]
+    )
+
+
+def _ensure_skill(
+    conn,
+    *,
+    package_id: int,
+    key: str,
+    name: str,
+    description: str,
+    tools: list[str],
+    timeout: int,
+    sort_order: int,
+) -> None:
+    config = json.dumps({"builtin_type": "context_tools", "tools": tools})
+    row = conn.execute(
+        text(
+            "SELECT id FROM skills "
+            "WHERE key = :key AND tenant_id IS NULL AND is_deleted = false "
+            "ORDER BY id LIMIT 1"
+        ),
+        {"key": key},
+    ).fetchone()
+    if row:
+        conn.execute(
+            text(
+                "UPDATE skills "
+                "SET package_id = :package_id, name = :name, "
+                "    description = :description, type = 'builtin', "
+                "    source_type = 'platform_builtin', version = '1.0.0', "
+                "    status = 'active', is_readonly = true, "
+                "    config = CAST(:config AS jsonb), is_system = true, "
+                "    is_active = true, timeout = :timeout, "
+                "    sort_order = :sort_order, updated_at = NOW() "
+                "WHERE id = :id"
+            ),
+            {
+                "id": row[0],
+                "package_id": package_id,
+                "name": name,
+                "description": description,
+                "config": config,
+                "timeout": timeout,
+                "sort_order": sort_order,
+            },
+        )
+        return
+
+    conn.execute(
+        text(
+            "INSERT INTO skills "
+            "(tenant_id, package_id, name, key, description, type, source_type, "
+            " version, status, is_readonly, config, is_system, is_active, "
+            " timeout, sort_order, created_at, updated_at, is_deleted) "
+            "VALUES "
+            "(NULL, :package_id, :name, :key, :description, 'builtin', "
+            " 'platform_builtin', '1.0.0', 'active', true, "
+            " CAST(:config AS jsonb), true, true, "
+            " :timeout, :sort_order, NOW(), NOW(), false)"
+        ),
+        {
+            "package_id": package_id,
+            "name": name,
+            "key": key,
+            "description": description,
+            "config": config,
+            "timeout": timeout,
+            "sort_order": sort_order,
+        },
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    package_id = _ensure_package(conn)
+    _ensure_skill(
+        conn,
+        package_id=package_id,
+        key=KB_SKILL_KEY,
+        name=KB_SKILL_NAME,
+        description=(
+            "检索当前智能体绑定的知识库，返回片段、来源与引用线索。"
+            "工具 schema 由代码定义。"
+        ),
+        tools=["search_agent_knowledge_base"],
+        timeout=45,
+        sort_order=0,
+    )
+    _ensure_skill(
+        conn,
+        package_id=package_id,
+        key=MEMORY_SKILL_KEY,
+        name=MEMORY_SKILL_NAME,
+        description=(
+            "保存与召回当前用户在当前智能体下的长期记忆。"
+            "工具 schema 由代码定义。"
+        ),
+        tools=["save_long_term_memory", "recall_long_term_memory"],
+        timeout=30,
+        sort_order=1,
+    )
+    print("[SEED] System context tools skill package seeded.")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            "DELETE FROM skills "
+            "WHERE key IN (:kb_key, :memory_key) "
+            "  AND tenant_id IS NULL AND is_system = true"
+        ),
+        {"kb_key": KB_SKILL_KEY, "memory_key": MEMORY_SKILL_KEY},
+    )
+    conn.execute(
+        text(
+            "DELETE FROM skill_packages "
+            "WHERE name = :name AND tenant_id IS NULL AND is_system = true"
+        ),
+        {"name": SKILL_PACKAGE_NAME},
+    )
+    print("[SEED] System context tools skill package removed.")

--- a/backend/tests/ai/context/test_rag_contributor.py
+++ b/backend/tests/ai/context/test_rag_contributor.py
@@ -69,4 +69,4 @@ async def test_rag_contributor_reports_skipped_status_without_fabricating_source
     assert contribution.rag_sources is None
     assert contribution.kb_injected is False
     assert contribution.rag_attempted is False
-    assert contribution.rag_retrieval_status == "skipped_shortcircuit"
+    assert contribution.rag_retrieval_status == "skipped_tool_managed"

--- a/backend/tests/ai/context/test_rag_contributor.py
+++ b/backend/tests/ai/context/test_rag_contributor.py
@@ -69,4 +69,4 @@ async def test_rag_contributor_reports_skipped_status_without_fabricating_source
     assert contribution.rag_sources is None
     assert contribution.kb_injected is False
     assert contribution.rag_attempted is False
-    assert contribution.rag_retrieval_status == "skipped_not_knowledge_intent"
+    assert contribution.rag_retrieval_status == "skipped_shortcircuit"

--- a/backend/tests/ai/engine/test_context_pipeline_orchestrator.py
+++ b/backend/tests/ai/engine/test_context_pipeline_orchestrator.py
@@ -18,12 +18,14 @@ def _request(
     memory_enabled: bool = False,
     long_term_memory_enabled: bool = False,
     memory_runtime_policy: dict | None = None,
+    has_bound_kb: bool = False,
 ):
     return SimpleNamespace(
         user_id=7,
         memory_enabled=memory_enabled,
         long_term_memory_enabled=long_term_memory_enabled,
         memory_runtime_policy=memory_runtime_policy or {},
+        _has_bound_knowledge_base=has_bound_kb,
     )
 
 
@@ -42,6 +44,18 @@ def test_context_pipeline_orchestrator_enables_runtime_memory_for_generic_turns(
     assert flags.long_term_memory_runtime_enabled is True
     assert flags.should_run_memory_profile is False
     assert flags.should_run_memory_vector_recall is True
+    assert flags.should_skip_bound_kb_rag is False
+
+
+def test_context_pipeline_orchestrator_keeps_bound_kb_rag_for_direct_reply() -> None:
+    flags = ContextPipelineOrchestrator.compute_intent_flags(
+        [_intent("direct_reply", shortcircuit=True)],
+        request=_request(has_bound_kb=True),
+    )
+
+    assert flags.all_shortcircuit is True
+    assert flags.has_bound_kb is True
+    assert flags.should_skip_bound_kb_rag is False
 
 
 def test_context_pipeline_orchestrator_keeps_session_memory_without_long_term_recall() -> (
@@ -73,6 +87,7 @@ def test_context_pipeline_orchestrator_runs_profile_and_recall_for_memory_recall
     assert flags.memory_context_enabled is True
     assert flags.has_memory_recall_intent is True
     assert flags.allow_memory_even_if_shortcircuit is True
+    assert flags.should_skip_bound_kb_rag is True
     assert flags.should_run_memory_profile is True
     assert flags.should_run_memory_vector_recall is True
 

--- a/backend/tests/ai/engine/test_context_pipeline_orchestrator.py
+++ b/backend/tests/ai/engine/test_context_pipeline_orchestrator.py
@@ -29,7 +29,7 @@ def _request(
     )
 
 
-def test_context_pipeline_orchestrator_enables_runtime_memory_for_generic_turns() -> (
+def test_context_pipeline_orchestrator_leaves_memory_to_context_tools() -> (
     None
 ):
     flags = ContextPipelineOrchestrator.compute_intent_flags(
@@ -38,12 +38,12 @@ def test_context_pipeline_orchestrator_enables_runtime_memory_for_generic_turns(
     )
 
     assert flags.has_memory_intent is False
-    assert flags.memory_context_enabled is True
+    assert flags.memory_context_enabled is False
     assert flags.allow_memory_even_if_shortcircuit is False
     assert flags.session_memory_runtime_enabled is True
     assert flags.long_term_memory_runtime_enabled is True
     assert flags.should_run_memory_profile is False
-    assert flags.should_run_memory_vector_recall is True
+    assert flags.should_run_memory_vector_recall is False
     assert flags.should_skip_bound_kb_rag is False
 
 
@@ -67,7 +67,7 @@ def test_context_pipeline_orchestrator_keeps_session_memory_without_long_term_re
     )
 
     assert flags.has_memory_intent is False
-    assert flags.memory_context_enabled is True
+    assert flags.memory_context_enabled is False
     assert flags.allow_memory_even_if_shortcircuit is False
     assert flags.session_memory_runtime_enabled is True
     assert flags.long_term_memory_runtime_enabled is False
@@ -75,7 +75,7 @@ def test_context_pipeline_orchestrator_keeps_session_memory_without_long_term_re
     assert flags.should_run_memory_vector_recall is False
 
 
-def test_context_pipeline_orchestrator_runs_profile_and_recall_for_memory_recall() -> (
+def test_context_pipeline_orchestrator_does_not_auto_recall_for_legacy_memory_intent() -> (
     None
 ):
     flags = ContextPipelineOrchestrator.compute_intent_flags(
@@ -84,12 +84,12 @@ def test_context_pipeline_orchestrator_runs_profile_and_recall_for_memory_recall
     )
 
     assert flags.has_memory_intent is True
-    assert flags.memory_context_enabled is True
+    assert flags.memory_context_enabled is False
     assert flags.has_memory_recall_intent is True
-    assert flags.allow_memory_even_if_shortcircuit is True
-    assert flags.should_skip_bound_kb_rag is True
-    assert flags.should_run_memory_profile is True
-    assert flags.should_run_memory_vector_recall is True
+    assert flags.allow_memory_even_if_shortcircuit is False
+    assert flags.should_skip_bound_kb_rag is False
+    assert flags.should_run_memory_profile is False
+    assert flags.should_run_memory_vector_recall is False
 
 
 def test_context_pipeline_orchestrator_keeps_memory_save_write_only() -> None:
@@ -99,7 +99,7 @@ def test_context_pipeline_orchestrator_keeps_memory_save_write_only() -> None:
     )
 
     assert flags.has_memory_intent is True
-    assert flags.memory_context_enabled is True
+    assert flags.memory_context_enabled is False
     assert flags.has_memory_save_intent is True
     assert flags.should_run_memory_profile is False
     assert flags.should_run_memory_vector_recall is False

--- a/backend/tests/ai/engine/test_intent_domain_rules.py
+++ b/backend/tests/ai/engine/test_intent_domain_rules.py
@@ -4,8 +4,6 @@ Scope: deterministic intent-domain classification and tool-family selection.
 Mocked dependencies: none; assertions exercise real IntentDomainRules logic.
 """
 
-from types import SimpleNamespace
-
 from app.ai.engine.intent_domain_rules import IntentDomainRules
 from app.ai.tools.types import ToolDefinition
 
@@ -35,23 +33,15 @@ def _detect(
     )
 
 
-def test_intent_domain_rules_detects_memory_save_and_recall() -> None:
+def test_intent_domain_rules_leaves_memory_to_context_tools() -> None:
     recall = _detect("你还记得我吗")
-    assert len(recall) == 1
-    assert recall[0].kind == "memory_recall"
-    assert recall[0].requires_tools is False
-    assert recall[0].shortcircuit is True
+    assert recall == []
 
     save = _detect("请记住这个")
-    assert len(save) == 1
-    assert save[0].kind == "memory_save"
-    assert save[0].requires_tools is False
-    assert save[0].shortcircuit is True
+    assert save == []
 
     long_term_save = _detect("我叫大致坡，请把这个信息存入长期记忆")
-    assert len(long_term_save) == 1
-    assert long_term_save[0].kind == "memory_save"
-    assert long_term_save[0].shortcircuit is True
+    assert long_term_save == []
 
 
 def test_intent_domain_rules_suppresses_for_no_tool_or_capability() -> None:
@@ -64,9 +54,7 @@ def test_intent_domain_rules_suppresses_for_no_tool_or_capability() -> None:
     memory_save = _detect(
         "不要使用任何工具，但请记住这个偏好", tools=_tools_weather_time()
     )
-    assert len(memory_save) == 1
-    assert memory_save[0].kind == "memory_save"
-    assert memory_save[0].requires_tools is False
+    assert memory_save == []
 
 
 def test_intent_domain_rules_leaves_plugin_weather_to_metadata_and_detects_time() -> (
@@ -91,19 +79,7 @@ def test_intent_domain_rules_detects_time_query_for_city_time_tool_directive() -
     assert signals[0].shortcircuit is True
 
 
-def test_intent_domain_rules_detects_knowledge_query_when_kb_bound() -> None:
-    kb_bundle = SimpleNamespace(context_sources=[{"kind": "knowledge_base"}])
-
-    knowledge = _detect("向量数据库是什么", capability_bundle=kb_bundle)
-    assert len(knowledge) == 1
-    assert knowledge[0].kind == "knowledge_query"
-    assert knowledge[0].requires_tools is False
-    assert knowledge[0].metadata.get("routing_mode") == "structured_semantic"
-
-    intro = _detect("介绍一下退货政策", capability_bundle=kb_bundle)
-    assert len(intro) == 1
-    assert intro[0].kind == "knowledge_query"
-
-    memory_first = _detect("记住这个：向量数据库是什么", capability_bundle=kb_bundle)
-    assert len(memory_first) == 1
-    assert memory_first[0].kind in {"memory_save", "memory_recall"}
+def test_intent_domain_rules_leaves_knowledge_query_to_context_tools() -> None:
+    assert _detect("向量数据库是什么") == []
+    assert _detect("介绍一下退货政策") == []
+    assert _detect("记住这个：向量数据库是什么") == []

--- a/backend/tests/ai/engine/test_intent_planner.py
+++ b/backend/tests/ai/engine/test_intent_planner.py
@@ -54,13 +54,13 @@ def test_intent_planner_does_not_route_plugin_weather_when_network_disabled() ->
     assert intents[0].shortcircuit is True
 
 
-def test_intent_planner_memory_save_uses_local_cached_ack() -> None:
+def test_intent_planner_leaves_memory_save_to_context_tools() -> None:
     intents = _plan("我叫ix long  请记住")
 
-    assert [intent.kind for intent in intents] == ["memory_save"]
+    assert [intent.kind for intent in intents] == ["direct_reply"]
     assert intents[0].shortcircuit is True
     assert intents[0].requires_tools is False
-    assert intents[0].cached_result == "已记住。"
+    assert intents[0].cached_result is None
 
 
 def test_intent_planner_ignores_invalid_runtime_context_for_page_summary() -> None:

--- a/backend/tests/ai/engine/test_system_prompt_helpers.py
+++ b/backend/tests/ai/engine/test_system_prompt_helpers.py
@@ -249,3 +249,31 @@ def test_resolve_capability_injection_decision_does_not_advertise_page_context()
     assert decision["kb_injected"] is False
     assert decision["memory_injected"] is False
     assert decision["skills_injected"] is False
+
+
+def test_resolve_capability_injection_decision_uses_bound_kb_flag() -> None:
+    """
+    Test type: behavioral
+    Scope: bound KB state, not knowledge intent classification, drives KB
+    injection diagnostics.
+    """
+
+    class _Source:
+        def __init__(self, kind: str, active: bool = True) -> None:
+            self.kind = kind
+            self.active = active
+
+    decision = resolve_capability_injection_decision(
+        diagnostics={},
+        intent_flags={
+            "all_shortcircuit": False,
+            "has_bound_kb": True,
+            "has_knowledge_intent": False,
+            "has_memory_intent": False,
+            "memory_context_enabled": False,
+        },
+        context_sources=[_Source("knowledge_base")],
+        capability_summary_injected=True,
+    )
+
+    assert decision["kb_injected"] is True

--- a/backend/tests/ai/tools/test_context_tool_executor.py
+++ b/backend/tests/ai/tools/test_context_tool_executor.py
@@ -5,6 +5,7 @@ Mocked dependencies: long-term memory provider and KB binding loader.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -105,8 +106,9 @@ async def test_context_tool_search_treats_zero_tenant_as_platform_context() -> N
         )
 
     assert result.success is True
-    assert '"status": "ok"' in result.output
-    assert "https://nvuai.cc" in result.output
+    output = json.loads(result.output)
+    assert output["status"] == "ok"
+    assert output["snippets"][0]["content"] == "官网：https://nvuai.cc"
     admin_repo_cls.assert_called_once_with(context.db)
     tenant_repo_cls.assert_not_called()
     retriever_cls.assert_called_once_with(context.db, None)

--- a/backend/tests/ai/tools/test_context_tool_executor.py
+++ b/backend/tests/ai/tools/test_context_tool_executor.py
@@ -1,0 +1,183 @@
+"""Test type: behavioral
+Scope: system context tool executor argument and provider behavior.
+Mocked dependencies: long-term memory provider and KB binding loader.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.ai.context_tools.tools import (
+    TOOL_RECALL_LONG_TERM_MEMORY,
+    TOOL_SAVE_LONG_TERM_MEMORY,
+    TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+    build_context_tool_definitions,
+)
+from app.ai.tools.executors.context_tool_executor import ContextToolExecutor
+from app.ai.tools.types import ExecutionContext
+
+
+def _definition(name: str):
+    return next(tool for tool in build_context_tool_definitions() if tool.name == name)
+
+
+def _context() -> ExecutionContext:
+    return ExecutionContext(
+        tenant_id=7,
+        agent_id=11,
+        user_id=3,
+        db=object(),
+        conversation_id=99,
+        agent=SimpleNamespace(rag_config={"top_k": 3}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_context_tool_search_reports_no_bound_kb() -> None:
+    executor = ContextToolExecutor()
+
+    with patch(
+        "app.ai.tools.executors.context_tool_executor.load_agent_kb_bindings",
+        new=AsyncMock(return_value=(None, {})),
+    ):
+        result = await executor.execute(
+            _definition(TOOL_SEARCH_AGENT_KNOWLEDGE_BASE),
+            "tc-1",
+            {"query": "仓库地址"},
+            _context(),
+        )
+
+    assert result.success is True
+    assert "no_effective_knowledge_base" in result.output
+
+
+@pytest.mark.asyncio
+async def test_context_tool_search_treats_zero_tenant_as_platform_context() -> None:
+    executor = ContextToolExecutor()
+    kb = SimpleNamespace(
+        id=5,
+        name="NovusAI SaaS框架知识库",
+        rag_config={},
+    )
+    chunk = SimpleNamespace(
+        chunk_id=91,
+        knowledge_base_id=5,
+        document_id=17,
+        document_name="NovusAI SaaS框架官网.txt",
+        chunk_index=0,
+        score=1.0,
+        content="官网：https://nvuai.cc",
+        recall_sources=["keyword"],
+    )
+    kb_repo = SimpleNamespace(get_by_id=AsyncMock(return_value=kb))
+    retriever = SimpleNamespace(search=AsyncMock(return_value=[chunk]))
+    context = ExecutionContext(
+        tenant_id=0,
+        agent_id=11,
+        user_id=3,
+        db=object(),
+        conversation_id=99,
+        agent=SimpleNamespace(rag_config={"top_k": 3}),
+    )
+
+    with (
+        patch(
+            "app.ai.tools.executors.context_tool_executor.load_agent_kb_bindings",
+            new=AsyncMock(return_value=([5], {5: 1.0})),
+        ),
+        patch(
+            "app.repositories.ai.knowledge_base_repository.AdminKnowledgeBaseRepository",
+            return_value=kb_repo,
+        ) as admin_repo_cls,
+        patch(
+            "app.repositories.ai.knowledge_base_repository.KnowledgeBaseRepository",
+        ) as tenant_repo_cls,
+        patch("app.ai.rag.retriever.HybridRetriever", return_value=retriever) as retriever_cls,
+    ):
+        result = await executor.execute(
+            _definition(TOOL_SEARCH_AGENT_KNOWLEDGE_BASE),
+            "tc-platform",
+            {"query": "NovusAI SaaS框架官网"},
+            context,
+        )
+
+    assert result.success is True
+    assert '"status": "ok"' in result.output
+    assert "https://nvuai.cc" in result.output
+    admin_repo_cls.assert_called_once_with(context.db)
+    tenant_repo_cls.assert_not_called()
+    retriever_cls.assert_called_once_with(context.db, None)
+    retriever.search.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_context_tool_save_memory_uses_provider() -> None:
+    executor = ContextToolExecutor()
+    provider = SimpleNamespace(
+        capture=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id=1,
+                    memory_type="fact",
+                    summary="用户喜欢简洁回复",
+                    content="用户喜欢简洁回复",
+                    importance=60,
+                    confidence=70,
+                    updated_at=None,
+                )
+            ]
+        )
+    )
+
+    with patch(
+        "app.services.ai.long_term_memory_provider.get_long_term_memory_provider",
+        return_value=provider,
+    ):
+        result = await executor.execute(
+            _definition(TOOL_SAVE_LONG_TERM_MEMORY),
+            "tc-2",
+            {"content": "用户喜欢简洁回复", "memory_type": "fact"},
+            _context(),
+        )
+
+    assert result.success is True
+    assert "saved" in result.output
+    provider.capture.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_context_tool_recall_memory_uses_provider() -> None:
+    executor = ContextToolExecutor()
+    provider = SimpleNamespace(
+        recall=AsyncMock(
+            return_value=[
+                SimpleNamespace(
+                    id=2,
+                    memory_type="preference",
+                    summary="用户偏好中文",
+                    content="用户偏好中文",
+                    importance=60,
+                    confidence=70,
+                    updated_at=None,
+                )
+            ]
+        )
+    )
+
+    with patch(
+        "app.services.ai.long_term_memory_provider.get_long_term_memory_provider",
+        return_value=provider,
+    ):
+        result = await executor.execute(
+            _definition(TOOL_RECALL_LONG_TERM_MEMORY),
+            "tc-3",
+            {"query": "语言偏好"},
+            _context(),
+        )
+
+    assert result.success is True
+    assert "用户偏好中文" in result.output
+    provider.recall.assert_awaited_once()

--- a/backend/tests/integration/ai/test_context_engine_capabilities.py
+++ b/backend/tests/integration/ai/test_context_engine_capabilities.py
@@ -252,18 +252,12 @@ async def test_context_engine_only_surfaces_session_memory_context_source_when_i
 
 
 @pytest.mark.asyncio
-async def test_context_engine_enables_long_term_memory_recall_on_generic_turns() -> (
+async def test_context_engine_leaves_long_term_memory_recall_to_context_tools() -> (
     None
 ):
-    memory_contribution = MemoryContextContribution(
-        memory_recalled=True,
-        memory_recall_slice={"count": 2, "scope_type": "user_agent"},
-        memory_injected=True,
-    )
-
     with patch(
         "app.ai.context.contributors.memory.MemoryContributor.contribute",
-        new=AsyncMock(return_value=memory_contribution),
+        new=AsyncMock(return_value=MemoryContextContribution()),
     ) as contribute_mock:
         assembly = await _assemble_context(
             request=_build_request(
@@ -276,16 +270,20 @@ async def test_context_engine_enables_long_term_memory_recall_on_generic_turns()
         )
 
     contribute_kwargs = contribute_mock.await_args.kwargs
-    assert contribute_kwargs["enabled"] is True
+    assert contribute_kwargs["enabled"] is False
     assert contribute_kwargs["should_run_memory_profile"] is False
-    assert contribute_kwargs["should_run_memory_vector_recall"] is True
-    assert assembly.memory_recalled is True
+    assert contribute_kwargs["should_run_memory_vector_recall"] is False
+    assert assembly.memory_recalled is False
     assert assembly.capability_bundle is not None
-    assert {
+    active_source_kinds = {
         source.kind
         for source in assembly.capability_bundle.context_sources
         if source.active
-    } >= {"long_term_memory"}
+    }
+    assert "long_term_memory" not in active_source_kinds
+    assert assembly.diagnostics["intent_flags"]["long_term_memory_runtime_enabled"] is (
+        True
+    )
 
 
 @pytest.mark.asyncio
@@ -563,11 +561,11 @@ async def test_context_engine_injects_limited_knowledge_base_capabilities() -> N
 
 
 @pytest.mark.asyncio
-async def test_context_engine_injects_bound_kb_for_generic_turns() -> None:
+async def test_context_engine_reports_tool_managed_bound_kb_for_generic_turns() -> None:
     """
-    中文: 测试类型 behavioral；绑定知识库的普通轮次也会执行 RAG 与能力上下文。
-    EN: Test type behavioral; generic turns with bound KB still run retrieval and
-    capability context.
+    中文: 测试类型 behavioral；绑定知识库的普通轮次暴露能力上下文，RAG 由上下文工具管理。
+    EN: Test type behavioral; generic turns with bound KB surface capability
+    context while retrieval is managed by context tools.
     """
     assembly = await _assemble_context(
         request=_build_request(
@@ -592,8 +590,8 @@ async def test_context_engine_injects_bound_kb_for_generic_turns() -> None:
 
     assert assembly.diagnostics["intent_flags"]["has_bound_kb"] is True
     assert assembly.diagnostics["intent_flags"]["has_knowledge_intent"] is False
-    assert assembly.diagnostics["rag_attempted"] is True
-    assert assembly.diagnostics["rag_retrieval_status"] == "attempted_no_results"
+    assert assembly.diagnostics["rag_attempted"] is False
+    assert assembly.diagnostics["rag_retrieval_status"] == "skipped_tool_managed"
     assert "[RUNTIME KNOWLEDGE CONTEXT METADATA]" in assembly.messages[0].content
     assert "项目知识库" in assembly.messages[0].content
     assert "knowledge_base" in assembly.diagnostics["context_source_kinds"]

--- a/backend/tests/integration/ai/test_context_engine_capabilities.py
+++ b/backend/tests/integration/ai/test_context_engine_capabilities.py
@@ -563,6 +563,43 @@ async def test_context_engine_injects_limited_knowledge_base_capabilities() -> N
 
 
 @pytest.mark.asyncio
+async def test_context_engine_injects_bound_kb_for_generic_turns() -> None:
+    """
+    中文: 测试类型 behavioral；绑定知识库的普通轮次也会执行 RAG 与能力上下文。
+    EN: Test type behavioral; generic turns with bound KB still run retrieval and
+    capability context.
+    """
+    assembly = await _assemble_context(
+        request=_build_request(
+            messages=[ChatMessage(role="user", content="仓库地址是多少")],
+        ),
+        skill_result=None,
+        settings=TenantCapabilityAwarenessSettings(
+            capability_description_style="concise",
+            max_capability_items_per_category=2,
+        ),
+        kb_ids=[101],
+        kb_bindings=[
+            {
+                "kb_id": 101,
+                "kb_name": "项目知识库",
+                "kb_description": "包含仓库地址与部署说明",
+                "kb_document_count": 3,
+            },
+        ],
+        intent_plan=_build_intent_plan("assistant_response"),
+    )
+
+    assert assembly.diagnostics["intent_flags"]["has_bound_kb"] is True
+    assert assembly.diagnostics["intent_flags"]["has_knowledge_intent"] is False
+    assert assembly.diagnostics["rag_attempted"] is True
+    assert assembly.diagnostics["rag_retrieval_status"] == "attempted_no_results"
+    assert "[RUNTIME KNOWLEDGE CONTEXT METADATA]" in assembly.messages[0].content
+    assert "项目知识库" in assembly.messages[0].content
+    assert "knowledge_base" in assembly.diagnostics["context_source_kinds"]
+
+
+@pytest.mark.asyncio
 async def test_context_engine_does_not_inject_capability_block_when_disabled() -> None:
     """
     中文: 测试类型 behavioral；关闭租户能力感知后不会注入运行时能力块。

--- a/backend/tests/regressions/test_context_tools_required_fallback.py
+++ b/backend/tests/regressions/test_context_tools_required_fallback.py
@@ -1,0 +1,148 @@
+"""
+Issue #20 (PR #40 review): context_tools required fallback regression.
+
+Test type: behavioral.
+
+Original symptom: user sends "你好" (plain greeting) with context skill bound
+but no effective knowledge base and long_term_memory_enabled=False. The system
+promoted the direct_reply to context_tools_query with ToolUsePolicy(mode="required"),
+forcing the model to call search_agent_knowledge_base / save_long_term_memory /
+recall_long_term_memory before answering a simple greeting.
+
+Expected: when context tools are only present via the unconditional default
+fallback (no semantic match, no pending confirmation), they must remain
+optional (mode="auto") so the model can freely answer with plain text.
+
+Real dependencies: plan_execution_tools, _default_context_tools_for_direct_reply.
+Mocked dependencies: none.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.ai.engine.prepare_execution_tool_helpers import plan_execution_tools
+from app.ai.engine.types import ExecutionRequest, IntentPlan
+from app.ai.tools.types import ToolDefinition
+
+
+def _build_context_tools() -> list[ToolDefinition]:
+    """Build the 3 context skill tools (same names as the real seed)."""
+    return [
+        ToolDefinition(
+            name="search_agent_knowledge_base",
+            description="Search the knowledge base bound to this agent.",
+            semantic_family="context_tools",
+            semantic_tags=["知识库", "knowledge base", "rag", "search"],
+        ),
+        ToolDefinition(
+            name="save_long_term_memory",
+            description="Save a fact to long-term memory.",
+            semantic_family="context_tools",
+            semantic_tags=["记忆", "memory", "save"],
+        ),
+        ToolDefinition(
+            name="recall_long_term_memory",
+            description="Recall facts from long-term memory.",
+            semantic_family="context_tools",
+            semantic_tags=["记忆", "memory", "recall"],
+        ),
+    ]
+
+
+def _build_diagnostics_direct_reply() -> dict:
+    return {
+        "intent_plan": [
+            IntentPlan(
+                intent_id="intent-1",
+                kind="direct_reply",
+                family="none",
+                order=1,
+                user_visible_label="direct_reply",
+                source_text="你好",
+                requires_tools=False,
+                shortcircuit=True,
+            ).to_dict()
+        ]
+    }
+
+
+def test_greeting_with_context_tools_no_required_fallback() -> None:
+    """'你好' + context tools bound + no KB + no memory → must NOT be required."""
+    context_tools = _build_context_tools()
+    request = ExecutionRequest(agent_id=1, tenant_id=0, messages=[])
+    messages = [SimpleNamespace(role="user", content="你好")]
+
+    plan = plan_execution_tools(
+        agent_id=1,
+        conversation_id=100,
+        request=request,
+        messages=messages,  # type: ignore[arg-type]
+        tools=list(context_tools),
+        all_tools=list(context_tools),
+        diagnostics=_build_diagnostics_direct_reply(),
+    )
+
+    # Policy must be auto, NOT required
+    assert plan.tool_use_policy.mode == "auto"
+    assert plan.tool_use_policy.family == "none"
+    assert plan.tool_use_policy.reason == "direct_reply_optional_context_tools"
+    assert plan.tool_use_policy.retry_on_contract_breach is False
+
+    # Intent must remain direct_reply, NOT promoted to context_tools_query
+    intent = plan.intent_plan[0]
+    assert intent.kind == "direct_reply"
+    assert intent.family == "none"
+    assert intent.requires_tools is False
+    assert intent.shortcircuit is True
+
+    # Context tools should still be visible as optional candidates
+    assert set(plan.tool_use_policy.allowed_tool_names) == {
+        "search_agent_knowledge_base",
+        "save_long_term_memory",
+        "recall_long_term_memory",
+    }
+
+
+def test_semantic_match_still_promotes_to_required() -> None:
+    """When user query semantically matches a tool, promotion to required still works."""
+    tools = [
+        ToolDefinition(
+            name="search_agent_knowledge_base",
+            description="Search the knowledge base bound to this agent.",
+            semantic_family="context_tools",
+            semantic_tags=["知识库", "knowledge base", "rag", "search"],
+        ),
+    ]
+    request = ExecutionRequest(agent_id=1, tenant_id=0, messages=[])
+    # This query should match "知识库" semantic tag
+    messages = [SimpleNamespace(role="user", content="帮我查一下知识库里的内容")]
+
+    plan = plan_execution_tools(
+        agent_id=1,
+        conversation_id=101,
+        request=request,
+        messages=messages,  # type: ignore[arg-type]
+        tools=list(tools),
+        all_tools=list(tools),
+        diagnostics={
+            "intent_plan": [
+                IntentPlan(
+                    intent_id="intent-1",
+                    kind="direct_reply",
+                    family="none",
+                    order=1,
+                    user_visible_label="direct_reply",
+                    source_text="帮我查一下知识库里的内容",
+                    requires_tools=False,
+                    shortcircuit=True,
+                ).to_dict()
+            ]
+        },
+    )
+
+    # Semantic match should promote to required
+    intent = plan.intent_plan[0]
+    assert intent.kind != "direct_reply"
+    assert intent.requires_tools is True
+    assert plan.tool_use_policy.mode == "required"

--- a/backend/tests/regressions/test_conversation_2412_kb_context_status.py
+++ b/backend/tests/regressions/test_conversation_2412_kb_context_status.py
@@ -4,13 +4,13 @@ Regression for: conversation_id=2412
 Original symptom: the user asked "看看绑定的知识库有什么内容"; the turn was a
 knowledge_query with active KB id=1, but the prompt had no stable KB status and
 the assistant claimed it could not inspect the bound knowledge base.
-Scope: context assembly and RAG status contract for bound-KB/no-source turns.
+Scope: context assembly and RAG status contract for bound-KB/tool-managed turns.
 Real dependencies: ConversationContextEngine, prompt contract renderer, runtime
 capability finalization, and diagnostics shaping.
 Mocked dependencies: tenant config, KB binding read model, intent fixture, model
-capability lookup, and RAG retrieval transport returning no sources.
+capability lookup, and RAG retrieval transport guard.
 Why this is not self-fulfilling: no LLM response is mocked; the test asserts
-the runtime-provided context contract that the model receives before generation.
+the runtime-provided context contract that tells the model to use context tools.
 """
 
 from __future__ import annotations
@@ -78,16 +78,13 @@ def _knowledge_intent() -> list[IntentPlan]:
 
 
 @pytest.mark.asyncio
-async def test_conversation_2412_bound_kb_no_source_turn_gets_prompt_visible_status() -> (
+async def test_conversation_2412_bound_kb_turn_gets_tool_managed_prompt_status() -> (
     None
 ):
     context_engine = ConversationContextEngine(
         db=object(),
         base_engine=_BaseEngineStub(),
     )
-
-    async def _rag_no_sources(_db, _agent, messages, _tenant_id, **_kwargs):
-        return messages, None
 
     with (
         patch(
@@ -109,8 +106,8 @@ async def test_conversation_2412_bound_kb_no_source_turn_gets_prompt_visible_sta
         ),
         patch(
             "app.ai.rag_injector.inject_rag_context",
-            new=AsyncMock(side_effect=_rag_no_sources),
-        ),
+            new=AsyncMock(),
+        ) as inject_mock,
         patch(
             "app.ai.context.engine_runtime_support.load_compaction_snapshot",
             new=AsyncMock(return_value=None),
@@ -143,17 +140,18 @@ async def test_conversation_2412_bound_kb_no_source_turn_gets_prompt_visible_sta
     assert "[RUNTIME KNOWLEDGE CONTEXT METADATA]" in system_prompt
     assert "测试知识库" in system_prompt
     assert '"document_count":2' in system_prompt
-    assert '"status":"attempted_no_results"' in system_prompt
+    assert '"status":"skipped_tool_managed"' in system_prompt
     assert 'Only retrieval.status="injected"' in system_prompt
 
     assert assembly.rag_sources is None
     assert assembly.diagnostics["effective_knowledge_base_ids"] == [1]
-    assert assembly.diagnostics["rag_attempted"] is True
-    assert assembly.diagnostics["rag_retrieval_status"] == "attempted_no_results"
-    assert assembly.diagnostics["rag_no_hit_reason"] == "retrieval_returned_no_sources"
+    assert assembly.diagnostics["rag_attempted"] is False
+    assert assembly.diagnostics["rag_retrieval_status"] == "skipped_tool_managed"
+    assert assembly.diagnostics["rag_no_hit_reason"] is None
     assert assembly.diagnostics["capability_injection_decision"]["kb_injected"] is (
         False
     )
+    inject_mock.assert_not_awaited()
 
     knowledge_sources = [
         source
@@ -182,9 +180,9 @@ async def test_conversation_2412_bound_kb_no_source_turn_gets_prompt_visible_sta
                 "binding_restriction_applied": False,
                 "rag_source_count": 0,
                 "rag_source_kinds": [],
-                "rag_attempted": True,
-                "rag_retrieval_status": "attempted_no_results",
-                "rag_no_hit_reason": "retrieval_returned_no_sources",
+                "rag_attempted": False,
+                "rag_retrieval_status": "skipped_tool_managed",
+                "rag_no_hit_reason": None,
                 "rag_matched_chunk_count": 0,
             },
         }

--- a/backend/tests/services/test_agent_skill_grant_service.py
+++ b/backend/tests/services/test_agent_skill_grant_service.py
@@ -26,13 +26,45 @@ class _EmptyExecuteResult:
         return None
 
 
-class _StatementCaptureDb:
-    def __init__(self) -> None:
-        self.statements: list[Any] = []
+class _SingleExecuteResult:
+    def __init__(self, value: Any) -> None:
+        self.value = value
 
-    async def execute(self, stmt: Any) -> _EmptyExecuteResult:
+    def scalar_one_or_none(self) -> Any:
+        return self.value
+
+
+class _ListScalarResult:
+    def __init__(self, values: list[Any]) -> None:
+        self.values = values
+
+    def all(self) -> list[Any]:
+        return self.values
+
+
+class _ListExecuteResult:
+    def __init__(self, values: list[Any]) -> None:
+        self.values = values
+
+    def scalars(self) -> _ListScalarResult:
+        return _ListScalarResult(self.values)
+
+
+class _StatementCaptureDb:
+    def __init__(self, result: Any | None = None) -> None:
+        self.statements: list[Any] = []
+        self.result = result or _EmptyExecuteResult()
+
+    async def execute(self, stmt: Any) -> Any:
         self.statements.append(stmt)
-        return _EmptyExecuteResult()
+        return self.result
+
+
+def _select_loads_skill_package(stmt: Any) -> bool:
+    return any(
+        "Skill.package" in str(getattr(option, "path", ""))
+        for option in getattr(stmt, "_with_options", ())
+    )
 
 
 @pytest.mark.asyncio
@@ -293,6 +325,49 @@ async def test_bind_skill_rejects_inactive_package_skill() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bind_skill_allows_platform_system_skill_with_loaded_package() -> None:
+    from app.services.ai.agent_skill_grant_service import AgentSkillGrantService
+
+    active_package = SimpleNamespace(
+        id=11,
+        name="智能体上下文技能包（内置）",
+        tenant_id=None,
+        is_active=True,
+        is_deleted=False,
+    )
+    context_skill = SimpleNamespace(
+        id=3,
+        name="知识库检索工具",
+        key="agent_context_knowledge_search",
+        source_ref="agent_context_knowledge_search",
+        tenant_id=None,
+        is_active=True,
+        is_deleted=False,
+        package=active_package,
+    )
+    created_grant = SimpleNamespace(id=17, agent_id=59, skill_id=3)
+
+    service = AgentSkillGrantService.__new__(AgentSkillGrantService)
+    service.db = AsyncMock()
+    service.tenant_id = 9
+    service.agent_repo = AsyncMock()
+    service.agent_repo.get_by_id = AsyncMock(
+        return_value=SimpleNamespace(id=59, owner_tenant_id=9),
+    )
+    service.skill_repo = AsyncMock()
+    service.skill_repo.get_by_id = AsyncMock(return_value=context_skill)
+    service.grant_repo = AsyncMock()
+    service.grant_repo.get_grant = AsyncMock(return_value=None)
+    service.grant_repo.create = AsyncMock(return_value=created_grant)
+
+    grant = await service.bind_skill(agent_id=59, skill_id=3)
+
+    assert grant is created_grant
+    service.grant_repo.create.assert_awaited_once()
+    assert service.grant_repo.create.await_args.args[0]["tenant_id"] == 9
+
+
+@pytest.mark.asyncio
 async def test_bind_skill_rejects_retired_online_search_skill() -> None:
     from app.exceptions import NotFoundException
     from app.services.ai.agent_skill_grant_service import AgentSkillGrantService
@@ -356,3 +431,67 @@ async def test_grant_repository_queries_filter_retired_skill_catalog() -> None:
         assert "replace" in sql
         assert "web_search" in params
         assert "searchprovider" in params
+
+
+@pytest.mark.asyncio
+async def test_skill_repository_get_by_id_eager_loads_package_for_binding() -> None:
+    from app.repositories.ai.skill_repository import SkillRepository
+
+    active_package = SimpleNamespace(
+        tenant_id=None,
+        is_active=True,
+        is_deleted=False,
+        name="智能体上下文技能包（内置）",
+    )
+    skill = SimpleNamespace(
+        id=3,
+        tenant_id=None,
+        package_id=11,
+        name="知识库检索工具",
+        key="agent_context_knowledge_search",
+        source_ref="agent_context_knowledge_search",
+        is_active=True,
+        is_deleted=False,
+        package=active_package,
+    )
+    db = _StatementCaptureDb(_SingleExecuteResult(skill))
+    repo = SkillRepository(db, tenant_id=9)
+
+    found = await repo.get_by_id(3)
+
+    assert found is skill
+    assert len(db.statements) == 1
+    assert _select_loads_skill_package(db.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_skill_repository_get_by_ids_eager_loads_package_for_batch_binding() -> (
+    None
+):
+    from app.repositories.ai.skill_repository import SkillRepository
+
+    active_package = SimpleNamespace(
+        tenant_id=None,
+        is_active=True,
+        is_deleted=False,
+        name="智能体上下文技能包（内置）",
+    )
+    skill = SimpleNamespace(
+        id=3,
+        tenant_id=None,
+        package_id=11,
+        name="长期记忆读写工具",
+        key="agent_context_memory_tools",
+        source_ref="agent_context_memory_tools",
+        is_active=True,
+        is_deleted=False,
+        package=active_package,
+    )
+    db = _StatementCaptureDb(_ListExecuteResult([skill]))
+    repo = SkillRepository(db, tenant_id=9)
+
+    found = await repo.get_by_ids([3])
+
+    assert found == [skill]
+    assert len(db.statements) == 1
+    assert _select_loads_skill_package(db.statements[0])

--- a/backend/tests/services/test_conversation_engine_prepare_execution.py
+++ b/backend/tests/services/test_conversation_engine_prepare_execution.py
@@ -13,6 +13,7 @@ import pytest
 
 from app.ai.context import get_context_engine
 from app.ai.context.engine import ConversationContextEngine
+from app.ai.context_tools.tools import build_context_tool_definitions
 from app.ai.engine.base import BaseEngine
 from app.ai.engine.conversation import ConversationEngine
 from app.ai.engine.conversation_sync_io_adapter import _SyncIOAdapter
@@ -55,6 +56,10 @@ def _build_skill_result() -> SkillResolveResult:
             ToolDefinition(name="query_records", description="Query platform data"),
         ]
     )
+
+
+def _build_context_skill_result() -> SkillResolveResult:
+    return SkillResolveResult(tools=[*build_context_tool_definitions()])
 
 
 def _build_structured_skill_result() -> SkillResolveResult:
@@ -770,7 +775,7 @@ async def test_context_engine_after_turn_refreshes_compaction_snapshot() -> None
 
 
 @pytest.mark.asyncio
-async def test_prepare_execution_injects_long_term_memory_recall_when_enabled() -> None:
+async def test_prepare_execution_exposes_memory_recall_context_tool_when_enabled() -> None:
     engine = ConversationEngine(
         db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
     )
@@ -810,7 +815,7 @@ async def test_prepare_execution_injects_long_term_memory_recall_when_enabled() 
         ),
         patch(
             "app.ai.engine.intent_planner.IntentPlanner.plan_turn",
-            return_value=_build_intent_plan("memory_recall"),
+            return_value=_build_intent_plan("direct_reply"),
         ),
         patch("app.ai.routing.router.ModelRouter", new=_FakeRouter),
         patch(
@@ -821,16 +826,20 @@ async def test_prepare_execution_injects_long_term_memory_recall_when_enabled() 
         prep = await engine._prepare_execution(
             agent,
             request,
-            skill_result=_build_skill_result(),
+            skill_result=_build_context_skill_result(),
         )
 
-    assert prep.memory_recalled is True
-    assert prep.memory_recall_slice == {"count": 1, "scope_type": "user_agent"}
-    assert "[LONG-TERM MEMORY RECALL]" in prep.messages[0].content
+    provider.profile.assert_not_awaited()
+    provider.recall.assert_not_awaited()
+    assert prep.memory_recalled is False
+    assert prep.memory_recall_slice is None
+    assert "[LONG-TERM MEMORY RECALL]" not in prep.messages[0].content
+    assert "recall_long_term_memory" in [tool.name for tool in prep.tools]
+    assert "recall_long_term_memory" in prep.tool_use_policy.allowed_tool_names
 
 
 @pytest.mark.asyncio
-async def test_prepare_execution_injects_profile_snapshot_before_recall() -> None:
+async def test_prepare_execution_leaves_profile_snapshot_to_memory_tool() -> None:
     engine = ConversationEngine(
         db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
     )
@@ -867,7 +876,7 @@ async def test_prepare_execution_injects_profile_snapshot_before_recall() -> Non
         ),
         patch(
             "app.ai.engine.intent_planner.IntentPlanner.plan_turn",
-            return_value=_build_intent_plan("memory_recall"),
+            return_value=_build_intent_plan("direct_reply"),
         ),
         patch("app.ai.routing.router.ModelRouter", new=_FakeRouter),
         patch(
@@ -878,16 +887,16 @@ async def test_prepare_execution_injects_profile_snapshot_before_recall() -> Non
         prep = await engine._prepare_execution(
             agent,
             request,
-            skill_result=_build_skill_result(),
+            skill_result=_build_context_skill_result(),
         )
 
-    assert prep.memory_recalled is True
-    assert prep.memory_recall_slice == {
-        "count": 0,
-        "profile_snapshot": True,
-        "scope_type": "user_agent",
-    }
-    assert "[PROFILE SNAPSHOT]" in prep.messages[0].content
+    provider.profile.assert_not_awaited()
+    provider.recall.assert_not_awaited()
+    assert prep.memory_recalled is False
+    assert prep.memory_recall_slice is None
+    assert "[PROFILE SNAPSHOT]" not in prep.messages[0].content
+    assert "recall_long_term_memory" in [tool.name for tool in prep.tools]
+    assert "recall_long_term_memory" in prep.tool_use_policy.allowed_tool_names
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
+++ b/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
@@ -121,3 +121,64 @@ async def test_prepare_execution_injects_bound_kb_for_definition_question() -> N
         "Knowledge-base context is available this turn." not in prep.messages[0].content
     )
     inject_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_prepare_execution_injects_bound_kb_for_plain_question() -> None:
+    engine = ConversationEngine(
+        db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
+    )
+    request = ExecutionRequest(
+        agent_id=1,
+        tenant_id=1,
+        user_id=7,
+        messages=[ChatMessage(role="user", content="仓库地址是多少")],
+        input_variables={},
+    )
+
+    async def _fake_inject_rag_context(
+        _db,
+        _agent,
+        messages,
+        _tenant_id,
+        kb_ids=None,
+        rag_config=None,
+        kb_weights=None,
+    ):
+        _ = _db, _agent, _tenant_id, rag_config, kb_weights
+        assert kb_ids == [101]
+        return (
+            messages
+            + [ChatMessage(role="system", content="[KB HIT] repository-url")],
+            [{"kb_id": 101, "chunk_id": "repository-url"}],
+        )
+
+    with (
+        patch(
+            "app.ai.rag_injector.load_agent_kb_bindings",
+            new=AsyncMock(return_value=([101], {101: 1.0})),
+        ),
+        patch(
+            "app.ai.rag_injector.inject_rag_context",
+            new=AsyncMock(side_effect=_fake_inject_rag_context),
+        ) as inject_mock,
+        patch("app.ai.routing.router.ModelRouter", new=_FakeRouter),
+    ):
+        prep = await engine._prepare_execution(
+            _build_agent(),
+            request,
+            skill_result=_build_skill_result(),
+        )
+
+    assert [intent.kind for intent in prep.intent_plan] == ["direct_reply"]
+    assert prep.execution_path == "fast"
+    assert prep.rag_source_kinds == ["formal_kb"]
+    assert prep.diagnostics["intent_flags"]["has_bound_kb"] is True
+    assert prep.diagnostics["intent_flags"]["has_knowledge_intent"] is False
+    assert prep.diagnostics["rag_attempted"] is True
+    assert "knowledge_base" in prep.diagnostics["context_source_kinds"]
+    assert (
+        "knowledge_base"
+        in prep.diagnostics["runtime_capability_summary"]["context_source_kinds"]
+    )
+    inject_mock.assert_awaited_once()

--- a/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
+++ b/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
@@ -99,15 +99,17 @@ async def test_prepare_execution_exposes_context_tool_for_definition_question() 
             skill_result=_build_skill_result(),
         )
 
-    assert [intent.kind for intent in prep.intent_plan] == ["context_tools_query"]
-    assert prep.execution_path == "normal"
+    # After fix: plain question without semantic tool match stays direct_reply
+    # with context tools as optional (mode="auto"), NOT promoted to required.
+    assert [intent.kind for intent in prep.intent_plan] == ["direct_reply"]
     assert prep.rag_source_kinds == []
     assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in [tool.name for tool in prep.tools]
     assert TOOL_SAVE_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
     assert TOOL_RECALL_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
     assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in prep.tool_use_policy.allowed_tool_names
-    assert prep.tool_use_policy.family == "context_tools"
-    assert prep.tool_use_policy.mode == "required"
+    assert prep.tool_use_policy.family == "none"
+    assert prep.tool_use_policy.mode == "auto"
+    assert prep.tool_use_policy.reason == "direct_reply_optional_context_tools"
     assert prep.diagnostics["rag_attempted"] is False
     assert prep.diagnostics["rag_retrieval_status"] == "skipped_tool_managed"
     assert "knowledge_base" in prep.diagnostics["context_source_kinds"]
@@ -151,15 +153,17 @@ async def test_prepare_execution_exposes_context_tool_for_plain_question() -> No
             skill_result=_build_skill_result(),
         )
 
-    assert [intent.kind for intent in prep.intent_plan] == ["context_tools_query"]
-    assert prep.execution_path == "normal"
+    # After fix: plain question without semantic tool match stays direct_reply
+    # with context tools as optional (mode="auto"), NOT promoted to required.
+    assert [intent.kind for intent in prep.intent_plan] == ["direct_reply"]
     assert prep.rag_source_kinds == []
     assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in [tool.name for tool in prep.tools]
     assert TOOL_SAVE_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
     assert TOOL_RECALL_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
     assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in prep.tool_use_policy.allowed_tool_names
-    assert prep.tool_use_policy.family == "context_tools"
-    assert prep.tool_use_policy.mode == "required"
+    assert prep.tool_use_policy.family == "none"
+    assert prep.tool_use_policy.mode == "auto"
+    assert prep.tool_use_policy.reason == "direct_reply_optional_context_tools"
     assert prep.diagnostics["intent_flags"]["has_bound_kb"] is True
     assert prep.diagnostics["intent_flags"]["has_knowledge_intent"] is False
     assert prep.diagnostics["rag_attempted"] is False

--- a/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
+++ b/backend/tests/services/test_conversation_engine_prepare_execution_kb_definition.py
@@ -8,6 +8,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.ai.context_tools.tools import (
+    TOOL_RECALL_LONG_TERM_MEMORY,
+    TOOL_SAVE_LONG_TERM_MEMORY,
+    TOOL_SEARCH_AGENT_KNOWLEDGE_BASE,
+    build_context_tool_definitions,
+)
 from app.ai.engine.conversation import ConversationEngine
 from app.ai.engine.types import ExecutionRequest
 from app.ai.skills.resolver import SkillResolveResult
@@ -43,6 +49,7 @@ def _build_skill_result() -> SkillResolveResult:
     return SkillResolveResult(
         tools=[
             ToolDefinition(name="query_records", description="Query platform data"),
+            *build_context_tool_definitions(),
         ]
     )
 
@@ -63,7 +70,7 @@ def _stub_missing_tool_runtime_summary_prompt(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_prepare_execution_injects_bound_kb_for_definition_question() -> None:
+async def test_prepare_execution_exposes_context_tool_for_definition_question() -> None:
     engine = ConversationEngine(
         db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
     )
@@ -75,23 +82,6 @@ async def test_prepare_execution_injects_bound_kb_for_definition_question() -> N
         input_variables={},
     )
 
-    async def _fake_inject_rag_context(
-        _db,
-        _agent,
-        messages,
-        _tenant_id,
-        kb_ids=None,
-        rag_config=None,
-        kb_weights=None,
-    ):
-        _ = _db, _agent, _tenant_id, rag_config, kb_weights
-        assert kb_ids == [101]
-        return (
-            messages
-            + [ChatMessage(role="system", content="[KB HIT] novusai-overview")],
-            [{"kb_id": 101, "chunk_id": "novusai-overview"}],
-        )
-
     with (
         patch(
             "app.ai.rag_injector.load_agent_kb_bindings",
@@ -99,7 +89,7 @@ async def test_prepare_execution_injects_bound_kb_for_definition_question() -> N
         ),
         patch(
             "app.ai.rag_injector.inject_rag_context",
-            new=AsyncMock(side_effect=_fake_inject_rag_context),
+            new=AsyncMock(),
         ) as inject_mock,
         patch("app.ai.routing.router.ModelRouter", new=_FakeRouter),
     ):
@@ -109,9 +99,17 @@ async def test_prepare_execution_injects_bound_kb_for_definition_question() -> N
             skill_result=_build_skill_result(),
         )
 
-    assert [intent.kind for intent in prep.intent_plan] == ["knowledge_query"]
+    assert [intent.kind for intent in prep.intent_plan] == ["context_tools_query"]
     assert prep.execution_path == "normal"
-    assert prep.rag_source_kinds == ["formal_kb"]
+    assert prep.rag_source_kinds == []
+    assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in [tool.name for tool in prep.tools]
+    assert TOOL_SAVE_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
+    assert TOOL_RECALL_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
+    assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in prep.tool_use_policy.allowed_tool_names
+    assert prep.tool_use_policy.family == "context_tools"
+    assert prep.tool_use_policy.mode == "required"
+    assert prep.diagnostics["rag_attempted"] is False
+    assert prep.diagnostics["rag_retrieval_status"] == "skipped_tool_managed"
     assert "knowledge_base" in prep.diagnostics["context_source_kinds"]
     assert (
         "knowledge_base"
@@ -120,11 +118,11 @@ async def test_prepare_execution_injects_bound_kb_for_definition_question() -> N
     assert (
         "Knowledge-base context is available this turn." not in prep.messages[0].content
     )
-    inject_mock.assert_awaited_once()
+    inject_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_prepare_execution_injects_bound_kb_for_plain_question() -> None:
+async def test_prepare_execution_exposes_context_tool_for_plain_question() -> None:
     engine = ConversationEngine(
         db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
     )
@@ -136,23 +134,6 @@ async def test_prepare_execution_injects_bound_kb_for_plain_question() -> None:
         input_variables={},
     )
 
-    async def _fake_inject_rag_context(
-        _db,
-        _agent,
-        messages,
-        _tenant_id,
-        kb_ids=None,
-        rag_config=None,
-        kb_weights=None,
-    ):
-        _ = _db, _agent, _tenant_id, rag_config, kb_weights
-        assert kb_ids == [101]
-        return (
-            messages
-            + [ChatMessage(role="system", content="[KB HIT] repository-url")],
-            [{"kb_id": 101, "chunk_id": "repository-url"}],
-        )
-
     with (
         patch(
             "app.ai.rag_injector.load_agent_kb_bindings",
@@ -160,7 +141,7 @@ async def test_prepare_execution_injects_bound_kb_for_plain_question() -> None:
         ),
         patch(
             "app.ai.rag_injector.inject_rag_context",
-            new=AsyncMock(side_effect=_fake_inject_rag_context),
+            new=AsyncMock(),
         ) as inject_mock,
         patch("app.ai.routing.router.ModelRouter", new=_FakeRouter),
     ):
@@ -170,15 +151,22 @@ async def test_prepare_execution_injects_bound_kb_for_plain_question() -> None:
             skill_result=_build_skill_result(),
         )
 
-    assert [intent.kind for intent in prep.intent_plan] == ["direct_reply"]
-    assert prep.execution_path == "fast"
-    assert prep.rag_source_kinds == ["formal_kb"]
+    assert [intent.kind for intent in prep.intent_plan] == ["context_tools_query"]
+    assert prep.execution_path == "normal"
+    assert prep.rag_source_kinds == []
+    assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in [tool.name for tool in prep.tools]
+    assert TOOL_SAVE_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
+    assert TOOL_RECALL_LONG_TERM_MEMORY in [tool.name for tool in prep.tools]
+    assert TOOL_SEARCH_AGENT_KNOWLEDGE_BASE in prep.tool_use_policy.allowed_tool_names
+    assert prep.tool_use_policy.family == "context_tools"
+    assert prep.tool_use_policy.mode == "required"
     assert prep.diagnostics["intent_flags"]["has_bound_kb"] is True
     assert prep.diagnostics["intent_flags"]["has_knowledge_intent"] is False
-    assert prep.diagnostics["rag_attempted"] is True
+    assert prep.diagnostics["rag_attempted"] is False
+    assert prep.diagnostics["rag_retrieval_status"] == "skipped_tool_managed"
     assert "knowledge_base" in prep.diagnostics["context_source_kinds"]
     assert (
         "knowledge_base"
         in prep.diagnostics["runtime_capability_summary"]["context_source_kinds"]
     )
-    inject_mock.assert_awaited_once()
+    inject_mock.assert_not_awaited()

--- a/backend/tests/services/test_system_agent_seed_service.py
+++ b/backend/tests/services/test_system_agent_seed_service.py
@@ -11,6 +11,9 @@ import pytest
 from app.enums.agent import AgentStatusEnum
 from app.exceptions import BusinessException
 from app.services.system.system_agent_seed_service import (
+    CONTEXT_KB_SKILL_KEY,
+    CONTEXT_MEMORY_SKILL_KEY,
+    CONTEXT_SKILL_PACKAGE_NAME,
     SYSTEM_AGENT_FEATURES,
     SystemAgentSeedService,
 )
@@ -58,6 +61,30 @@ class FakeSeedRepository:
     ):
         _ = key, include_deleted
         return None
+
+    async def get_platform_system_skill_package_by_name(
+        self,
+        name: str,
+        *,
+        include_deleted: bool = False,
+    ):
+        _ = name, include_deleted
+        return None
+
+    async def get_platform_system_skill_by_key(
+        self,
+        key: str,
+        *,
+        include_deleted: bool = False,
+    ):
+        _ = key, include_deleted
+        return None
+
+    async def create_skill_package(self, data):
+        return SimpleNamespace(id=1, is_deleted=False, **data)
+
+    async def create_skill(self, data):
+        return SimpleNamespace(id=len(getattr(self, "created_skills", [])) + 10, is_deleted=False, **data)
 
 
 class FakeDb:
@@ -324,3 +351,44 @@ async def test_ensure_skill_rejects_non_system_key_conflict() -> None:
 
     with pytest.raises(BusinessException):
         await service._ensure_skill(SimpleNamespace(id=1))
+
+
+@pytest.mark.asyncio
+async def test_ensure_context_tool_skills_creates_db_visible_system_package() -> None:
+    class ContextSkillRepo(FakeSeedRepository):
+        def __init__(self) -> None:
+            super().__init__(model=_model(), provider=_provider())
+            self.created_packages = []
+            self.created_skills = []
+
+        async def create_skill_package(self, data):
+            self.created_packages.append(data)
+            return SimpleNamespace(id=88, is_deleted=False, **data)
+
+        async def create_skill(self, data):
+            self.created_skills.append(data)
+            return SimpleNamespace(
+                id=100 + len(self.created_skills),
+                is_deleted=False,
+                **data,
+            )
+
+    repo = ContextSkillRepo()
+    service = _service(repo)
+
+    package, skills = await service._ensure_context_tool_skills()
+
+    assert package.name == CONTEXT_SKILL_PACKAGE_NAME
+    assert package.is_system is True
+    assert [skill.key for skill in skills] == [
+        CONTEXT_KB_SKILL_KEY,
+        CONTEXT_MEMORY_SKILL_KEY,
+    ]
+    assert repo.created_skills[0]["config"] == {
+        "builtin_type": "context_tools",
+        "tools": ["search_agent_knowledge_base"],
+    }
+    assert repo.created_skills[1]["config"] == {
+        "builtin_type": "context_tools",
+        "tools": ["save_long_term_memory", "recall_long_term_memory"],
+    }

--- a/backend/tests/test_skill_resolver.py
+++ b/backend/tests/test_skill_resolver.py
@@ -683,6 +683,42 @@ async def test_resolve_for_agent_ignores_client_side_skill_selection_fields(
 
 
 @pytest.mark.asyncio
+async def test_resolve_for_agent_previews_context_tool_string_list_without_crashing(
+    monkeypatch,
+) -> None:
+    context_skill = _make_runtime_skill(
+        skill_id=622,
+        name="知识库检索工具",
+        skill_type="builtin",
+        package_name="智能体上下文技能包（内置）",
+        config={
+            "builtin_type": "context_tools",
+            "tools": ["search_agent_knowledge_base"],
+        },
+    )
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = [_make_grant(context_skill)]
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    agent = SimpleNamespace(id=1, owner_tenant_id=9)
+    request = SimpleNamespace(
+        messages=[SimpleNamespace(role="user", content="你知道怎么称呼我吗")],
+    )
+    captured: dict[str, object] = {}
+
+    async def _capture_resolve(self, skills, config_overrides=None):
+        captured["skills"] = skills
+        captured["config_overrides"] = config_overrides
+        return SkillResolveResult()
+
+    monkeypatch.setattr(SkillResolver, "resolve", _capture_resolve)
+
+    await resolve_for_agent(db, agent, tenant_id=9, request=request)
+
+    assert [skill.name for skill in captured["skills"]] == ["知识库检索工具"]
+
+
+@pytest.mark.asyncio
 async def test_resolve_for_agent_filters_retired_online_search_grants(
     monkeypatch,
 ) -> None:
@@ -733,7 +769,10 @@ async def test_resolve_for_agent_filters_retired_online_search_grants(
     resolved = await resolve_for_agent(db, agent, tenant_id=9, request=request)
 
     assert [skill.name for skill in captured["skills"]] == ["CRM Lookup"]
-    assert [tool.name for tool in resolved.tools] == ["crm_lookup", "get_current_time"]
+    assert [tool.name for tool in resolved.tools] == [
+        "crm_lookup",
+        "get_current_time",
+    ]
     assert "联网搜索" not in resolved.selected_skill_names
     assert "百度公开搜索" not in resolved.selected_skill_names
 
@@ -818,3 +857,39 @@ async def test_resolve_for_agent_prefilters_plugin_tool_mentions_from_manifest_p
     await resolve_for_agent(db, agent, tenant_id=9, request=request)
 
     assert [skill.name for skill in captured["skills"]] == ["Assistant Extension"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_does_not_inject_hidden_context_tools() -> None:
+    resolver = SkillResolver(db=None)
+
+    result = await resolver.resolve([])
+    resolver._inject_baseline_runtime_builtins(result)
+
+    assert [tool.name for tool in result.tools] == ["get_current_time"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_expands_db_visible_context_tool_skill_subset() -> None:
+    resolver = SkillResolver(db=None)
+    skill = _make_runtime_skill(
+        skill_id=901,
+        name="知识库检索工具",
+        skill_type="builtin",
+        package_name="智能体上下文技能包（内置）",
+        config={
+            "builtin_type": "context_tools",
+            "tools": ["search_agent_knowledge_base"],
+        },
+    )
+
+    result = await resolver.resolve([skill])
+
+    assert [tool.name for tool in result.tools] == ["search_agent_knowledge_base"]
+    assert result.tools[0].source_skill_name == "知识库检索工具"
+
+
+def test_time_only_runtime_result_does_not_inject_context_tools() -> None:
+    result = SkillResolver._build_time_only_runtime_result()
+
+    assert [tool.name for tool in result.tools] == ["get_current_time"]


### PR DESCRIPTION
## 变更说明

本 PR 完成 #20 的最终重构方向：将知识库检索与长期记忆读写从关键词意图规划器中移出，改为通过 DB 可见的系统内置技能包暴露给 LLM，由模型在 ReAct/tool calling 循环中自主选择是否调用。

## 核心变化

- 移除 `knowledge_query`、`memory_save`、`memory_recall` 的关键词/正则规划逻辑，只保留时间类确定性 short-circuit。
- 新增 `智能体上下文技能包（内置）`：
  - `知识库检索工具` -> `search_agent_knowledge_base`
  - `长期记忆读写工具` -> `save_long_term_memory`、`recall_long_term_memory`
- 新增上下文工具执行器，支持当前智能体绑定知识库检索与长期记忆读写。
- 系统智能体初始化会自动创建并绑定上下文技能包。
- 修复系统技能绑定时 `skill.package` 未加载导致的“技能不存在”。
- 修复管理端对话 `tenant_id=0` 场景下，知识库工具误判为不可访问的问题。

## 方案说明

issue 原始 AC 中曾提到“绑定 KB 后任意自然语言查询均触发 RAG 检索”。本 PR 按后续讨论调整为更接近主流 Agent/ReAct 的实现：不再每轮强制初始 RAG 注入，而是把 RAG 检索作为普通工具交给 LLM 自主规划调用。

因此当前语义是：

- 智能体绑定了上下文技能包后，LLM 能看到并主动调用知识库/记忆工具。
- 知识库是否检索由模型根据工具描述与当前问题判断。
- RAG/记忆不再依赖关键词命中，也不再由隐藏规则提前截断。

## 验证

本地已验证：

- 后台可正常绑定系统内置技能包。
- 智能体对话可调用 `search_agent_knowledge_base` 并检索到绑定知识库内容。
- 管理端平台上下文 `tenant_id=0` 可正确访问平台知识库。

命令验证：

- `backend/.venv/bin/ruff check ...` 通过
- #20 相关回归测试：`105 passed`

## 关联

Fixes #20

@eric134679 麻烦帮忙审核一下这个最终方案口径：本 PR 已从原先“绑定 KB 驱动初始 RAG”升级为“上下文系统技能包 + LLM 自主工具调用”的实现。
