### PR TITLE
fix(ai-chat): 修复流式半截输出完成态

### DIFF
--- a/backend/app/ai/engine/stream_execution_runtime.py
+++ b/backend/app/ai/engine/stream_execution_runtime.py
@@ -792,16 +792,9 @@ def _resolve_exception_final_output_source(
     state: Any,
     tool_results: list[Any],
 ) -> str | None:
+    _ = state, tool_results
     if not str(partial_output or "").strip():
         return None
-    intent_plan = (
-        list(getattr(state, "intent_plan", []) or []) if state is not None else []
-    )
-    if RecoveryManager.has_completed_output_evidence(
-        intent_plan,
-        tool_results=tool_results,
-    ):
-        return "recovery_evidence"
     return "partial_output"
 
 
@@ -914,6 +907,7 @@ async def _build_stream_exception_artifacts(
         )
         if rebuilt_completed_output:
             partial_output = rebuilt_completed_output
+            recovered_from_provider_failure = True
             state.preparation_diagnostics = dict(
                 getattr(state, "preparation_diagnostics", {}) or {}
             )

--- a/backend/app/ai/engine/stream_finalization_pipeline.py
+++ b/backend/app/ai/engine/stream_finalization_pipeline.py
@@ -85,17 +85,21 @@ def resolve_done_final_stage_status(
     turn_flow: dict[str, Any] | None,
     result: ExecutionResult,
 ) -> str:
-    if _as_list(_as_dict(turn_flow).get("timeline")):
-        return resolve_final_stage_status(turn_flow)
     if bool(getattr(result, "interrupted", False)):
         return "interrupted"
     completion_reason = str(getattr(result, "completion_reason", "") or "").strip()
+    if completion_reason == "interrupted":
+        return "interrupted"
+    if bool(getattr(result, "partial", False)):
+        return "error"
     if bool(getattr(result, "partial", False)) or completion_reason not in {
         "",
         "completed",
         "stop",
     }:
         return "error"
+    if _as_list(_as_dict(turn_flow).get("timeline")):
+        return resolve_final_stage_status(turn_flow)
     return resolve_final_stage_status(turn_flow)
 
 

--- a/backend/app/ai/engine/stream_generation_pipeline.py
+++ b/backend/app/ai/engine/stream_generation_pipeline.py
@@ -686,6 +686,7 @@ def finalize_successful_turn(
 
     diagnostics_payload = view.build_diagnostics_payload()
     diagnostics_payload["final_output_source"] = final_output_source
+    interrupted = paused_for_consent or completion_reason == "interrupted"
     result_turn_record, resolved_protocol_path = build_result_turn_record(
         handler,
         diagnostics_payload=diagnostics_payload,
@@ -708,7 +709,7 @@ def finalize_successful_turn(
         tool_results=tool_results,
         output=str(output or ""),
         completion_reason=completion_reason,
-        interrupted=paused_for_consent,
+        interrupted=interrupted,
         error=None,
     )
     diagnostics_payload["turn_flow"] = turn_flow
@@ -733,7 +734,7 @@ def finalize_successful_turn(
         conversation_id=view.request.conversation_id,
         runtime_model_info=view.runtime_model_info,
         partial=partial,
-        interrupted=paused_for_consent,
+        interrupted=interrupted,
         completion_reason=completion_reason,
         rag_sources=rag_sources,
         rag_source_kinds=view.rag_source_kinds,
@@ -751,9 +752,14 @@ def finalize_successful_turn(
         provider_events=view.provider_events,
     )
     if completion_reason == "length":
+        agent_id = getattr(
+            view.request,
+            "agent_id",
+            getattr(getattr(handler, "agent", None), "id", None),
+        )
         logger.warning(
             "Response hit output length limit: agent={} model={} total_tokens={} conversation_id={}",
-            view.request.agent_id,
+            agent_id,
             (view.runtime_model_info or {}).get("model_name"),
             total_tokens,
             view.request.conversation_id,

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -287,6 +287,38 @@ def cached_shortcircuit_intent(state: ExecutionStateMachine) -> Any | None:
     return None
 
 
+_SUCCESS_FINISH_REASONS = {"", "completed", "stop", "success"}
+_TOOL_CONTINUATION_FINISH_REASONS = {"function_call", "tool_calls"}
+_INTERRUPTED_FINISH_REASONS = {"canceled", "cancelled"}
+
+
+def _normalize_finish_reason(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _non_success_finish_completion_reason(response: ChatResponse | None) -> str:
+    finish_reason = _normalize_finish_reason(
+        getattr(response, "finish_reason", None)
+    )
+    if not finish_reason:
+        metadata = (
+            dict(getattr(response, "metadata", {}) or {})
+            if response is not None
+            else {}
+        )
+        finish_reason = _normalize_finish_reason(
+            metadata.get("finish_reason") or metadata.get("completion_reason")
+        )
+    if (
+        finish_reason in _SUCCESS_FINISH_REASONS
+        or finish_reason in _TOOL_CONTINUATION_FINISH_REASONS
+    ):
+        return ""
+    if finish_reason in _INTERRUPTED_FINISH_REASONS:
+        return "interrupted"
+    return finish_reason
+
+
 async def finalize_turn_execution(
     *,
     state: ExecutionStateMachine,
@@ -326,6 +358,9 @@ async def finalize_turn_execution(
         decision is not None and decision.action == "pause_for_consent"
     )
     partial = bool(decision is not None and decision.action == "return_partial")
+    non_success_finish_reason = _non_success_finish_completion_reason(response)
+    if not paused_for_consent and not partial and non_success_finish_reason:
+        partial = True
     _ = emit_round_started_cb
     if decision is not None and decision.action in {
         "pause_for_consent",
@@ -362,7 +397,11 @@ async def finalize_turn_execution(
         )
     elif partial:
         state.transition("partial_exit")
-        completion_reason = decision.reason or "return_partial"
+        completion_reason = (
+            (decision.reason if decision is not None else "")
+            or non_success_finish_reason
+            or "return_partial"
+        )
         output, total_tokens, completion_tokens_used = await io.finalize_partial_output(
             messages=messages,
             response=response,

--- a/backend/app/ai/engine/turn_flow_projector.py
+++ b/backend/app/ai/engine/turn_flow_projector.py
@@ -41,6 +41,11 @@ _TERMINAL_FAILURE_COMPLETION_REASONS = frozenset(
         "tool_round_failed",
         "stream_execution_error",
         "terminal_failure",
+        "length",
+        "content_filter",
+        "incomplete",
+        "cancelled",
+        "canceled",
     }
 )
 _TERMINAL_FAILURE_KINDS = frozenset(

--- a/backend/tests/ai/engine/test_stream_generation_pipeline.py
+++ b/backend/tests/ai/engine/test_stream_generation_pipeline.py
@@ -459,6 +459,63 @@ def test_done_payload_marks_partial_provider_failure_as_error_terminal() -> None
     assert done_payload["final_stage_status"] == "error"
 
 
+def test_done_payload_overrides_stale_completed_turn_flow_for_partial_result() -> None:
+    state = _StateStub(
+        {
+            "failure_kind": "provider_timeout",
+            "turn_outcome": "partial",
+            "final_output_source": "partial_output",
+        }
+    )
+    handler = SimpleNamespace(
+        request=SimpleNamespace(conversation_id=88),
+        prep=SimpleNamespace(stream_runtime=None),
+        start_time=0.0,
+        engine=SimpleNamespace(_messages_to_dicts=messages_to_dicts),
+        _state=state,
+        _runtime_turn_record=None,
+        _runtime_turn_record_source=None,
+        _runtime_turn_record_overlays={},
+    )
+
+    result = build_terminal_result(
+        handler,
+        messages=[],
+        output="NovusAI 的仓库地址是：",
+        error="AI 供应商请求超时",
+        interrupted=False,
+        completion_reason="provider_timeout",
+        total_tokens=21,
+        duration_ms=34,
+        tool_results=[],
+        rag_sources=[],
+        include_provider_state=True,
+    )
+    stale_turn_flow = {
+        "timeline": [{"id": "completed", "status": "completed", "type": "completed"}]
+    }
+    result.turn_record["turn_flow"] = stale_turn_flow
+    result.diagnostics = dict(result.diagnostics or {})
+    result.diagnostics["turn_flow"] = stale_turn_flow
+    artifacts = stream_finalization_pipeline.StreamFinalizationArtifacts(
+        result=result,
+        diagnostics_payload=result.diagnostics or {},
+        response_metadata={},
+        resolved_protocol_path="responses",
+    )
+
+    done_payload = build_done_event_payload(
+        request=handler.request,
+        artifacts=artifacts,
+        on_complete_extra=None,
+    )
+
+    assert result.partial is True
+    assert done_payload["turn_outcome"] == "partial"
+    assert done_payload["completion_reason"] == "provider_timeout"
+    assert done_payload["final_stage_status"] == "error"
+
+
 def test_finalize_completed_output_scopes_duplicate_check_to_current_turn() -> None:
     delegate = SimpleNamespace(
         _visible_stream_content="",

--- a/backend/tests/services/test_stream_handler_real_stream.py
+++ b/backend/tests/services/test_stream_handler_real_stream.py
@@ -1790,6 +1790,99 @@ async def test_interrupted_calls_on_complete_with_partial_result():
 
 
 @pytest.mark.asyncio
+async def test_provider_timeout_after_partial_chunk_finishes_as_partial_error():
+    from app.ai.engine.types import ExecutionResult
+
+    captured: list[ExecutionResult] = []
+    events: list[dict] = []
+
+    async def on_complete(result: ExecutionResult) -> None:
+        captured.append(result)
+
+    class _TimeoutAfterPartialEngine(_FakeEngine):
+        async def _stream_llm_chunks(self, **kwargs):
+            _ = kwargs
+            yield ChatChunk(delta="NovusAI 的仓库地址是：", total_tokens=9)
+            raise ProviderTimeoutError(message="Request timed out.")
+
+    handler = _build_handler(_TimeoutAfterPartialEngine())
+    handler.on_complete = on_complete
+
+    async for raw in handler.generate():
+        if raw.strip().startswith("data: {"):
+            events.append(_parse_sse_payload(raw))
+
+    if handler._background_tasks:
+        await asyncio.wait_for(
+            asyncio.gather(*list(handler._background_tasks)),
+            timeout=1,
+        )
+
+    message_text = "".join(
+        event.get("delta", "") for event in events if event.get("event") == "message"
+    )
+    done_payload = next(event for event in events if event.get("event") == "done")
+
+    assert "NovusAI 的仓库地址是：" in message_text
+    assert len(captured) == 1
+    result = captured[0]
+    assert result.partial is True
+    assert result.success is False
+    assert result.completion_reason == "provider_timeout"
+    assert done_payload["completion_reason"] == "provider_timeout"
+    assert done_payload["termination_reason"] == "provider_timeout"
+    assert done_payload["turn_outcome"] == "partial"
+    assert done_payload["final_stage_status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_length_finish_reason_after_partial_chunk_is_not_completed():
+    from app.ai.engine.types import ExecutionResult
+
+    captured: list[ExecutionResult] = []
+    events: list[dict] = []
+
+    async def on_complete(result: ExecutionResult) -> None:
+        captured.append(result)
+
+    engine = _FakeEngine(
+        rounds=[
+            [
+                ChatChunk(
+                    delta="NovusAI 的仓库地址是：",
+                    finish_reason="length",
+                    total_tokens=12,
+                )
+            ]
+        ]
+    )
+    handler = _build_handler(engine)
+    handler.on_complete = on_complete
+
+    async for raw in handler.generate():
+        if raw.strip().startswith("data: {"):
+            events.append(_parse_sse_payload(raw))
+
+    if handler._background_tasks:
+        await asyncio.wait_for(
+            asyncio.gather(*list(handler._background_tasks)),
+            timeout=1,
+        )
+
+    done_payload = next(event for event in events if event.get("event") == "done")
+
+    assert len(captured) == 1
+    result = captured[0]
+    assert result.partial is True
+    assert result.success is False
+    assert result.completion_reason == "length"
+    assert done_payload["completion_reason"] == "length"
+    assert done_payload["termination_reason"] == "length"
+    assert done_payload["turn_outcome"] == "partial"
+    assert done_payload["final_stage_status"] == "error"
+
+
+@pytest.mark.asyncio
 async def test_interrupted_without_visible_output_still_emits_readable_message():
     """
     无正文即被 CancelledError 中断时，仍要落成可读 interrupted 文案，而不是空白 assistant。

--- a/frontend/apps/web-antd/src/api/shared/types.ts
+++ b/frontend/apps/web-antd/src/api/shared/types.ts
@@ -177,13 +177,17 @@ export interface TurnFallbackRecordPayload {
 
 /** Turn-level diagnostics payload / 轮次级诊断负载 */
 export interface TurnRecordPayload {
+  completion_reason?: string;
   context_sources?: TurnContextSourcePayload[];
   fallback_history?: TurnFallbackRecordPayload[];
+  failure_kind?: string;
+  final_stage_status?: string;
   metadata?: Record<string, unknown>;
   protocol_path?: string;
   selected_skill_names?: string[];
   selected_tool_names?: string[];
   termination_reason?: string;
+  turn_flow?: Record<string, unknown>;
   turn_outcome?: string;
 }
 

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/ChatMessageContentBlock.vue
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/ChatMessageContentBlock.vue
@@ -298,6 +298,12 @@ function toggleExpand() {
       >
         {{ $t('common.globalAiChat.generationInterrupted') }}
       </span>
+      <span
+        v-else-if="msg.partial && !msg.requestFailedRetry && !msg.streaming"
+        class="ml-1 text-muted-foreground/70"
+      >
+        {{ $t('common.globalAiChat.generationIncomplete') }}
+      </span>
       <div
         v-if="canCollapse && !expanded"
         class="via-card/92 pointer-events-none absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-card to-transparent"

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/ChatMessageContentBlock.test.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/ChatMessageContentBlock.test.ts
@@ -221,6 +221,18 @@ function mountContentBlock(msg: ChatMessage) {
 }
 
 describe('chatMessageContentBlock', () => {
+  it('shows an incomplete marker for benign partial assistant content', () => {
+    const wrapper = mountContentBlock({
+      clientKey: 'partial-without-failure',
+      content: 'NovusAI 的仓库地址是：',
+      partial: true,
+      role: 'assistant',
+      streaming: false,
+    } as ChatMessage);
+
+    expect(wrapper.text()).toContain('common.globalAiChat.generationIncomplete');
+  });
+
   it('resets to collapsed state when message identity changes on the same component instance', async () => {
     const wrapper = mount(ChatMessageContentBlock, {
       props: {

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/use-ai-chat-history-cases.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/use-ai-chat-history-cases.ts
@@ -156,6 +156,66 @@ export function registerUseAIChatHistoryCases(
     expect(chat.chatMessages.value[1]?.interrupted).toBe(true);
   });
 
+  it('keeps provider timeout from reloaded history as a retryable failure', async () => {
+    apiMocks.getChatConversationMessagesApi.mockResolvedValue(
+      buildConversationDetail(
+        [
+          buildUserMessage('查一下仓库地址'),
+          buildAssistantMessage('NovusAI 的仓库地址是：', {
+            metadata: {
+              completion_reason: 'provider_timeout',
+              termination_reason: 'provider_timeout',
+              turn_record: {
+                completion_reason: 'provider_timeout',
+                termination_reason: 'provider_timeout',
+                turn_outcome: 'partial',
+              },
+            },
+          }),
+        ],
+        { interaction_mode_effective: 'trusted_auto' },
+      ),
+    );
+
+    apiMocks.sendChatStreamApi.mockImplementation(
+      async (
+        _prefix: string,
+        _agentId: number,
+        _body: Record<string, unknown>,
+        options: {
+          onEnd: () => Promise<void>;
+          onMessage: (chunk: string) => Promise<void>;
+        },
+      ) => {
+        await options.onMessage(
+          sseEvent({ event: 'conversation', conversation_id: 42 }),
+        );
+        await options.onMessage(
+          sseEvent({ event: 'message', delta: 'NovusAI 的仓库地址是：' }),
+        );
+        await options.onEnd();
+      },
+    );
+
+    const chat = createChat();
+
+    await chat.loadAgents();
+    chat.inputMessage.value = '查一下仓库地址';
+
+    await chat.sendMessage();
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+
+    const assistantMessage = chat.chatMessages.value[1];
+    expect(apiMocks.getChatConversationMessagesApi).toHaveBeenCalledTimes(1);
+    expect(assistantMessage?.content).toBe('NovusAI 的仓库地址是：');
+    expect(assistantMessage?.partial).toBe(true);
+    expect(assistantMessage?.completionReason).toBe('provider_timeout');
+    expect(assistantMessage?.terminationReason).toBe('provider_timeout');
+    expect(assistantMessage?.requestFailedRetry).toBe(true);
+  });
+
   it('keeps the anchored conversation binding after transient local state loss', async () => {
     apiMocks.getChatAgentsApi.mockResolvedValue(
       buildAgentList([

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/use-ai-chat.test.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/__tests__/use-ai-chat.test.ts
@@ -94,9 +94,11 @@ vi.mock('#/constants/upload', () => ({
 
 vi.mock('#/locales', () => ({
   $t: (key: string) => key,
+  i18n: { global: { locale: { value: 'zh-CN' } } },
 }));
 
 vi.mock('#/store', () => ({
+  useAIPanelStore: () => aiPanelStoreMocks,
   useSocketIOStore: () => ({
     connect: socketStoreMocks.connect,
     emit: socketStoreMocks.emit,
@@ -106,6 +108,10 @@ vi.mock('#/store', () => ({
 
 vi.mock('#/store/shared/ai-panel', () => ({
   useAIPanelStore: () => aiPanelStoreMocks,
+}));
+
+vi.mock('@vben/stores', () => ({
+  useUserStore: () => ({ userInfo: { realName: 'Test User' } }),
 }));
 
 vi.mock('#/utils/ai-consent', () => ({
@@ -1495,8 +1501,9 @@ describe('useAIChat interrupted stream recovery', () => {
 
     await chat.loadAgents();
     chat.inputMessage.value = '总结一下';
-    await chat.sendMessage();
+    const sendPromise = chat.sendMessage();
     await flushStreamSend();
+    await sendPromise;
 
     const assistantMessage = chat.chatMessages.value.find(
       (msg) => msg.role === 'assistant',
@@ -1506,12 +1513,63 @@ describe('useAIChat interrupted stream recovery', () => {
     expect(assistantMessage?.turnFlow?.completionReason).toBe(
       'provider_failure_after_partial_progress',
     );
+    expect(assistantMessage?.partial).toBe(true);
+    expect(assistantMessage?.requestFailedRetry).toBe(true);
+    expect(assistantMessage?.streaming).toBeFalsy();
+    expect(assistantMessage?.turnFlow?.turnOutcome).toBe('partial');
     expect(
       timeline.some(
         (stage) => stage.type === 'failed' && stage.status === 'error',
       ),
     ).toBe(true);
     expect(timeline.some((stage) => stage.status === 'running')).toBe(false);
+  });
+
+  it('projects provider timeout completion reason as failed even without explicit final status', async () => {
+    apiMocks.sendChatStreamApi.mockImplementation(
+      async (
+        _prefix: string,
+        _agentId: number,
+        _body: Record<string, unknown>,
+        options: {
+          onMessage: (chunk: string) => Promise<void>;
+        },
+      ) => {
+        await options.onMessage(
+          sseEvent({ event: 'conversation', conversation_id: 42 }),
+        );
+        await options.onMessage(
+          sseEvent({ event: 'message', delta: 'NovusAI 的仓库地址是：' }),
+        );
+        await options.onMessage(
+          sseEvent({
+            completion_reason: 'provider_timeout',
+            event: 'done',
+            total_tokens: 9,
+          }),
+        );
+      },
+    );
+
+    const chat = createChat();
+
+    await chat.loadAgents();
+    chat.inputMessage.value = '查一下仓库地址';
+    const sendPromise = chat.sendMessage();
+    await flushStreamSend();
+    await sendPromise;
+
+    const assistantMessage = chat.chatMessages.value.find(
+      (msg) => msg.role === 'assistant',
+    );
+
+    expect(assistantMessage?.content).toBe('NovusAI 的仓库地址是：');
+    expect(assistantMessage?.requestFailedRetry).toBe(true);
+    expect(assistantMessage?.turnFlow?.finalStageStatus).toBe('error');
+    expect(assistantMessage?.turnFlow?.completionReason).toBe(
+      'provider_timeout',
+    );
+    expect(assistantMessage?.streaming).toBeFalsy();
   });
 
   it('clears stale running canonical turn stages after lifecycle finalization', async () => {
@@ -2946,7 +3004,15 @@ describe('useAIChat interrupted stream recovery', () => {
       'consented_actions',
       'conversation_id',
       'message',
+      'user_context',
     ]);
+    expect(requestBody?.user_context).toEqual(
+      expect.objectContaining({
+        current_time: expect.any(String),
+        locale: 'zh-CN',
+        user_nickname: 'Test User',
+      }),
+    );
   });
 
   it('sends chat with only explicit chat request fields', async () => {
@@ -2984,7 +3050,15 @@ describe('useAIChat interrupted stream recovery', () => {
       'consented_actions',
       'conversation_id',
       'message',
+      'user_context',
     ]);
+    expect(requestBody?.user_context).toEqual(
+      expect.objectContaining({
+        current_time: expect.any(String),
+        locale: 'zh-CN',
+        user_nickname: 'Test User',
+      }),
+    );
     expect(requestBody).not.toHaveProperty('messages');
     expect(socketStoreMocks.connect).not.toHaveBeenCalled();
   });

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/chat-message-turn-flow-display-helpers.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/chat-message-turn-flow-display-helpers.ts
@@ -34,6 +34,9 @@ export interface TurnFlowForDisplay extends TurnFlowViewModel {
 }
 
 const FAILURE_COMPLETION_REASONS = new Set([
+  'content_filter',
+  'incomplete',
+  'length',
   'provider_error',
   'provider_failure_after_partial_progress',
   'provider_timeout',
@@ -41,6 +44,8 @@ const FAILURE_COMPLETION_REASONS = new Set([
   'stream_execution_error',
   'tool_error',
   'tool_round_failed',
+  'cancelled',
+  'canceled',
 ]);
 
 const TERMINAL_STAGE_TYPES = new Set<TurnFlowStageType>([

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/chat-message-turn-flow-ingestion.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/chat-message-turn-flow-ingestion.ts
@@ -50,6 +50,9 @@ export {
 const FAILURE_REASON_SET = new Set([
   'error',
   'failed',
+  'content_filter',
+  'incomplete',
+  'length',
   'no_answer_quality_evidence',
   'provider_error',
   'provider_failure_after_partial_progress',
@@ -59,6 +62,8 @@ const FAILURE_REASON_SET = new Set([
   'tool_error',
   'tool_round_failed',
   'untrusted_final_output_source',
+  'cancelled',
+  'canceled',
 ]);
 
 const FAILURE_OUTCOME_SET = new Set(['error', 'failed', 'tool_round_failed']);

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/use-ai-chat-message-context.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/use-ai-chat-message-context.ts
@@ -55,9 +55,19 @@ export function normalizeTurnRecord(value: unknown): null | TurnRecordPayload {
     return null;
   }
   const payload = value as Record<string, unknown>;
+  const completionReason = normalizeOptionalString(payload.completion_reason);
+  const failureKind = normalizeOptionalString(payload.failure_kind);
+  const finalStageStatus = normalizeOptionalString(payload.final_stage_status);
   const turnOutcome = normalizeOptionalString(payload.turn_outcome);
   const terminationReason = normalizeOptionalString(payload.termination_reason);
   const protocolPath = normalizeOptionalString(payload.protocol_path);
+  const turnFlow =
+    payload.turn_flow && typeof payload.turn_flow === 'object'
+      ? ({ ...(payload.turn_flow as Record<string, unknown>) } as Record<
+          string,
+          unknown
+        >)
+      : undefined;
   const selectedToolNames = normalizeRuntimeDiagnosticTokens(
     payload.selected_tool_names,
   );
@@ -80,6 +90,9 @@ export function normalizeTurnRecord(value: unknown): null | TurnRecordPayload {
         >)
       : undefined;
   return {
+    ...(completionReason ? { completion_reason: completionReason } : {}),
+    ...(failureKind ? { failure_kind: failureKind } : {}),
+    ...(finalStageStatus ? { final_stage_status: finalStageStatus } : {}),
     turn_outcome: turnOutcome,
     termination_reason: terminationReason,
     protocol_path: protocolPath,
@@ -89,8 +102,49 @@ export function normalizeTurnRecord(value: unknown): null | TurnRecordPayload {
     ...(fallbackHistory.length > 0
       ? { fallback_history: fallbackHistory }
       : {}),
+    ...(turnFlow ? { turn_flow: turnFlow } : {}),
     ...(metadata ? { metadata } : {}),
   };
+}
+
+const FAILURE_OUTCOMES = new Set(['error', 'failed', 'tool_round_failed']);
+const FAILURE_TERMINATIONS = new Set([
+  'budget_exit',
+  'candidate_tool_budget_exceeded',
+  'completion_budget_exceeded',
+  'content_filter',
+  'elapsed_budget_exceeded',
+  'error',
+  'failed',
+  'incomplete',
+  'length',
+  'prompt_budget_exceeded',
+  'provider_error',
+  'provider_failure_after_partial_progress',
+  'provider_timeout',
+  'provider_unavailable',
+  'stream_execution_error',
+  'terminal_failure',
+  'tool_error',
+  'tool_result_budget_exceeded',
+  'tool_round_budget_exceeded',
+  'tool_round_failed',
+  'untrusted_final_output_source',
+]);
+
+function isFailureTerminationSignal(value?: string): boolean {
+  if (!value) {
+    return false;
+  }
+  if (FAILURE_TERMINATIONS.has(value)) {
+    return true;
+  }
+  return (
+    value.startsWith('provider_') ||
+    value.includes('error') ||
+    value.includes('failed') ||
+    value.endsWith('_budget_exceeded')
+  );
 }
 
 export function isTurnFailure(
@@ -99,12 +153,8 @@ export function isTurnFailure(
 ): boolean {
   const normalizedOutcome = normalizeOptionalString(turnOutcome);
   const normalizedTermination = normalizeOptionalString(terminationReason);
-  const failureOutcomes = new Set(['error', 'failed', 'tool_round_failed']);
-  const failureTerminations = new Set(['error', 'failed', 'tool_error']);
   return (
-    (normalizedOutcome ? failureOutcomes.has(normalizedOutcome) : false) ||
-    (normalizedTermination
-      ? failureTerminations.has(normalizedTermination)
-      : false)
+    (normalizedOutcome ? FAILURE_OUTCOMES.has(normalizedOutcome) : false) ||
+    isFailureTerminationSignal(normalizedTermination)
   );
 }

--- a/frontend/apps/web-antd/src/components/business/ai-chat-panel/use-ai-chat-message-merge-turn-diagnostics.ts
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-panel/use-ai-chat-message-merge-turn-diagnostics.ts
@@ -29,6 +29,16 @@ export function collectTurnDiagnostics(
     state.turnRecordPayload = turnRecord;
   }
 
+  const metadataCompletionReason = normalizeOptionalString(
+    assistantMetadata?.completion_reason,
+  );
+  if (!state.turnCompletionReason && metadataCompletionReason) {
+    state.turnCompletionReason = metadataCompletionReason;
+  }
+  if (!state.turnCompletionReason && turnRecord?.completion_reason) {
+    state.turnCompletionReason = turnRecord.completion_reason;
+  }
+
   const metadataTurnOutcome = normalizeOptionalString(
     assistantMetadata?.turn_outcome,
   );


### PR DESCRIPTION
Fixes #21

## 变更
- 后端收紧流式终态语义：provider timeout、非 stop finish_reason、partial/interrupted 不再被 stale completed 或 done envelope 洗成普通完成态。
- 修正异常恢复 evidence 判定，只有真实重建出可信完整答案时才标记 recovered/completed。
- 前端统一 live SSE 与历史消息的失败/partial 投影，并为非错误但未完整的 partial 内容增加轻量未完成提示。
- 补充 provider timeout、length finish_reason、stale turn_flow、history reload、UI marker 等回归测试。

## 验证
- `python -m py_compile app\ai\engine\stream_execution_runtime.py app\ai\engine\stream_finalization_pipeline.py app\ai\engine\stream_generation_pipeline.py app\ai\engine\turn_executor.py app\ai\engine\turn_flow_projector.py`
- `python -m pytest tests/ai/engine/test_stream_generation_pipeline.py tests/services/test_stream_handler_real_stream.py -q`
- `pnpm --dir frontend exec vitest run apps/web-antd/src/components/business/ai-chat-panel/__tests__/use-ai-chat.test.ts apps/web-antd/src/components/business/ai-chat-panel/__tests__/ChatMessageContentBlock.test.ts`
- `pnpm --dir frontend exec vue-tsc --noEmit --skipLibCheck --pretty false -p apps/web-antd/tsconfig.json`
- `git diff --check`