### PR TITLE
feat(internal-ops): 基于 RBAC 生成 AI 内部工具操作确认展示数据

### DIFF
--- a/backend/app/ai/engine/prepare_execution_tool_helpers.py
+++ b/backend/app/ai/engine/prepare_execution_tool_helpers.py
@@ -540,6 +540,62 @@ def plan_execution_tools(
             )
     # ── End Confirmation Replay Shortcircuit ──────────────────────────────────
 
+    # ── Confirmation Rejection Shortcircuit ───────────────────────────────────
+    # When the user rejects a pending confirmation, force a direct-reply turn
+    # without tools so the LLM generates a cancellation acknowledgement
+    # instead of trying to re-invoke the same tool.
+    # 用户拒绝授权确认时，强制走 direct_reply（无工具），让 LLM 生成取消回复
+    # 而不是再次尝试调用同一工具。
+    _has_current_confirmation_rejection = any(
+        str(u.get("kind") or "") == "pending_confirmation"
+        and bool(u.get("rejected"))
+        for u in (getattr(request, "interaction_updates", None) or [])
+        if isinstance(u, dict)
+    )
+    if _has_current_confirmation_rejection:
+        rejection_intent = IntentPlan(
+            intent_id="intent-confirm-reject",
+            kind="direct_reply",
+            family="none",
+            order=1,
+            user_visible_label="cancellation_acknowledgement",
+            source_text="",
+            requires_tools=False,
+            shortcircuit=True,
+            allowed_tool_names=[],
+            preferred_tool_names=[],
+            metadata={"routing_mode": "rejection_shortcircuit"},
+        )
+        rejection_policy = ToolUsePolicy(
+            family="none",
+            mode="auto",
+            allowed_tool_names=[],
+            retry_on_contract_breach=False,
+            reason="confirmation_rejection",
+        )
+        return PreparedExecutionToolPlan(
+            tools=[],
+            candidate_tool_names=[],
+            tool_use_policy=rejection_policy,
+            tool_planner={
+                "intent": "direct_reply",
+                "family": "none",
+                "reason": "rejection_shortcircuit",
+            },
+            optimize_event={
+                "total": len(all_tools),
+                "selected": 0,
+                "execution_path": "fast",
+            },
+            intent_plan=[rejection_intent],
+            intent_flags={"all_shortcircuit": True},
+            explicit_requested_families=[],
+            execution_path="fast",
+            execution_budget=BudgetGuard.build_default("fast", intent_count=1),
+            active_intent_id="intent-confirm-reject",
+        )
+    # ── End Confirmation Rejection Shortcircuit ───────────────────────────────
+
     raw_intent_plan = diagnostics.get("intent_plan")
     intent_plan = _deserialize_intent_plan_impl(raw_intent_plan)
     intent_flags = _intent_plan_gating_flags_impl(intent_plan, request=request)

--- a/backend/app/ai/engine/tool_processor_events.py
+++ b/backend/app/ai/engine/tool_processor_events.py
@@ -92,6 +92,13 @@ def build_confirmation_event(
         event["message"] = parsed.get("message", "")
         event["total_new"] = parsed.get("total_new", 0)
         event["total_conflict"] = parsed.get("total_conflict", 0)
+    # Pass through approval_presentation for frontend card rendering
+    # 透传 approval_presentation 避免卡片先显示原始数据再切换（闪烁）
+    approval = parsed.get("approval_presentation") or parsed.get(
+        "approvalPresentation"
+    )
+    if approval and isinstance(approval, dict):
+        event["approval_presentation"] = approval
     return event
 
 

--- a/backend/app/ai/engine/tool_processor_messages.py
+++ b/backend/app/ai/engine/tool_processor_messages.py
@@ -84,6 +84,13 @@ def build_pending_confirmation_payload(
     normalized_name = str(func_name or "").strip()
     if normalized_name:
         payload["tool_name"] = normalized_name
+    # Pass through approval_presentation for frontend card rendering
+    # 透传 approval_presentation 供前端确认卡片展示
+    approval = parsed.get("approval_presentation") or parsed.get(
+        "approvalPresentation"
+    )
+    if approval and isinstance(approval, dict):
+        payload["approval_presentation"] = approval
     return payload
 
 

--- a/backend/app/ai/internal_ops/approval_presentation.py
+++ b/backend/app/ai/internal_ops/approval_presentation.py
@@ -1,0 +1,391 @@
+"""
+Tool Approval Presentation Builder / 工具操作确认展示数据构建器
+
+Generates a user-readable ``ToolApprovalPresentation`` structure for
+``invoke_internal_operation`` write confirmations, so the frontend can
+render a meaningful approval card instead of raw JSON.
+
+基于 RBAC 权限树为内部操作写确认生成用户可读展示数据，
+供前端确认卡片渲染，不额外调用 LLM。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logging import LogManager
+from app.models.auth.permission import Permission
+from app.rbac.services.permission_domains.presentation import (
+    PermissionPresentationDomain,
+)
+
+logger = LogManager.get_logger("ai.internal_ops.approval_presentation")
+
+# ── Sensitive field filtering / 敏感字段过滤 ──────────────────────────────
+
+_SENSITIVE_KEYWORDS: frozenset[str] = frozenset({
+    "password",
+    "passwd",
+    "token",
+    "secret",
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "headers",
+    "access_token",
+    "refresh_token",
+    "secret_key",
+    "private_key",
+    "credential",
+})
+
+_SENSITIVE_RE = re.compile(
+    "|".join(
+        re.escape(kw.replace("_", "").replace("-", ""))
+        for kw in _SENSITIVE_KEYWORDS
+    ),
+    re.IGNORECASE,
+)
+
+# ── Action label mapping / 操作标签映射 ───────────────────────────────────
+
+_ACTION_LABELS: dict[str, str] = {
+    "create": "创建",
+    "update": "更新",
+    "delete": "删除",
+    "read": "查看",
+    "list": "查询列表",
+    "export": "导出",
+    "import": "导入",
+    "enable": "启用",
+    "disable": "禁用",
+    "reset": "重置",
+    "assign": "分配",
+    "revoke": "撤销",
+}
+
+# ── Risk level heuristics / 风险等级启发式 ─────────────────────────────────
+
+_HIGH_RISK_METHODS = frozenset({"DELETE"})
+_HIGH_RISK_ACTIONS = frozenset({"delete", "disable", "revoke", "reset"})
+
+
+# ── Data structures / 数据结构 ─────────────────────────────────────────────
+
+
+@dataclass
+class ApprovalTarget:
+    """Target entity of the operation / 操作目标实体"""
+
+    type: str | None = None
+    name: str | None = None
+
+
+@dataclass
+class ApprovalDetail:
+    """A single safe business detail / 单条安全业务详情"""
+
+    label: str
+    value: str
+    sensitive: bool = False
+
+
+@dataclass
+class ToolApprovalPresentation:
+    """User-readable confirmation card payload / 用户可读确认卡片数据"""
+
+    title: str
+    summary: str | None = None
+    risk_level: str | None = None  # low | medium | high
+    operation_type: str | None = None
+    permission_code: str | None = None
+    menu_label: str | None = None
+    action_label: str | None = None
+    target: ApprovalTarget | None = None
+    details: list[ApprovalDetail] = field(default_factory=list)
+    technical: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe dict / 序列化为 JSON 安全字典"""
+        data = asdict(self)
+        # Remove None top-level fields for cleaner JSON / 移除空字段
+        return {k: v for k, v in data.items() if v is not None and v != [] and v != {}}
+
+
+# ── Internal helpers / 内部辅助 ────────────────────────────────────────────
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Whether a field name is sensitive / 字段名是否敏感"""
+    normalized = key.replace("-", "").replace("_", "").lower()
+    return bool(_SENSITIVE_RE.search(normalized))
+
+
+def _infer_risk_level(method: str, action: str) -> str:
+    """Heuristic risk level from HTTP method + RBAC action / 从方法和操作推断风险等级"""
+    if method in _HIGH_RISK_METHODS or action in _HIGH_RISK_ACTIONS:
+        return "high"
+    if method in ("POST", "PATCH", "PUT"):
+        return "medium"
+    return "low"
+
+
+def _resolve_action_label(action: str) -> str:
+    """Translate an RBAC action to a display label / 将 RBAC 操作标识转为显示标签"""
+    if action in _ACTION_LABELS:
+        return _ACTION_LABELS[action]
+    return PermissionPresentationDomain.translate_name(action)
+
+
+def _extract_safe_details(
+    *,
+    body: dict[str, Any] | None,
+    path_params: dict[str, Any],
+    query_params: dict[str, Any],
+    max_fields: int = 10,
+) -> list[ApprovalDetail]:
+    """
+    Extract non-sensitive key-value pairs from request params /
+    从请求参数中提取非敏感键值对。
+
+    Sensitive keys are excluded entirely (not even shown with mask).
+    敏感字段完全排除（不展示，不传给 LLM）。
+    """
+    details: list[ApprovalDetail] = []
+
+    # Body fields (most relevant for write ops) / 请求体字段
+    if body and isinstance(body, dict):
+        for key, value in body.items():
+            if _is_sensitive_key(key):
+                continue
+            if value is None:
+                continue
+            display_value = _format_detail_value(value)
+            if display_value:
+                details.append(ApprovalDetail(label=key, value=display_value))
+                if len(details) >= max_fields:
+                    return details
+
+    # Path params (entity identifiers) / 路径参数
+    for key, value in path_params.items():
+        if _is_sensitive_key(key):
+            continue
+        display_value = _format_detail_value(value)
+        if display_value:
+            details.append(ApprovalDetail(label=key, value=display_value))
+            if len(details) >= max_fields:
+                return details
+
+    # Query params (supplementary) / 查询参数
+    for key, value in query_params.items():
+        if _is_sensitive_key(key):
+            continue
+        display_value = _format_detail_value(value)
+        if display_value:
+            details.append(ApprovalDetail(label=key, value=display_value))
+            if len(details) >= max_fields:
+                return details
+
+    return details
+
+
+def _format_detail_value(value: Any) -> str:
+    """Format a value for display, skipping complex nested objects / 格式化展示值"""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "是" if value else "否"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        text = value.strip()
+        # Skip overly long strings (likely blobs/JSON) / 跳过过长字符串
+        if len(text) > 200:
+            return ""
+        return text
+    # Skip dicts / lists (too complex for a summary card) / 跳过复杂结构
+    return ""
+
+
+def _build_title(
+    *,
+    action_label: str,
+    menu_label: str | None,
+    permission: Permission | None,
+    operation_summary: str,
+    method: str,
+    path: str,
+    permission_code: str,
+) -> str:
+    """
+    Build a human-readable title with stable fallback chain /
+    构建可读标题，带稳定兜底链。
+
+    Priority:
+    1. action_label + menu_label (e.g. "创建 套餐管理")
+    2. translated permission name
+    3. operation summary
+    4. method + path + permission_code
+    """
+    if permission is not None:
+        translated = PermissionPresentationDomain.translate_name(permission.name)
+        if translated and translated != permission.name:
+            if action_label and menu_label:
+                return f"{action_label} {menu_label}"
+            return translated
+
+    if action_label and menu_label:
+        return f"{action_label} {menu_label}"
+
+    if operation_summary:
+        return operation_summary
+
+    return f"{method} {path} ({permission_code})"
+
+
+# ── DB lookup / 数据库查询 ─────────────────────────────────────────────────
+
+
+async def _find_permission_by_code(
+    db: AsyncSession,
+    permission_code: str,
+) -> Permission | None:
+    """Look up a Permission record by code / 按权限码查找 Permission 记录"""
+    result = await db.execute(
+        select(Permission).where(Permission.code == permission_code).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _find_parent_menu(
+    db: AsyncSession,
+    permission: Permission,
+) -> Permission | None:
+    """
+    Walk up the parent chain to find the nearest menu-type ancestor /
+    沿父级链向上查找最近的菜单类型祖先。
+    """
+    current = permission
+    guard = 0
+    while current.parent_id is not None and guard < 10:
+        guard += 1
+        result = await db.execute(
+            select(Permission).where(Permission.id == current.parent_id)
+        )
+        parent = result.scalar_one_or_none()
+        if parent is None:
+            break
+        if parent.type == "menu":
+            return parent
+        current = parent
+    return None
+
+
+# ── Public API / 公开接口 ──────────────────────────────────────────────────
+
+
+async def build_approval_presentation(
+    *,
+    db: AsyncSession | None,
+    operation_id: str,
+    method: str,
+    path: str,
+    permission_code: str,
+    summary: str = "",
+    action: str = "",
+    body: dict[str, Any] | None = None,
+    path_params: dict[str, Any] | None,
+    query_params: dict[str, Any] | None,
+) -> ToolApprovalPresentation:
+    """
+    Build a ``ToolApprovalPresentation`` for a write operation confirmation /
+    为写操作确认构建展示数据。
+
+    This function is **pure lookup** — no LLM calls, no token consumption.
+    本函数纯查询，不调用 LLM，不消耗 token。
+    """
+    path_params = dict(path_params or {})
+    query_params = dict(query_params or {})
+
+    permission: Permission | None = None
+    menu_label: str | None = None
+
+    # DB-backed lookup (permission + parent menu) / 数据库查询权限与父菜单
+    if db is not None:
+        try:
+            permission = await _find_permission_by_code(db, permission_code)
+            if permission is not None:
+                parent_menu = await _find_parent_menu(db, permission)
+                if parent_menu is not None:
+                    menu_label = PermissionPresentationDomain.translate_name(
+                        parent_menu.name
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Approval presentation DB lookup failed for {}: {}",
+                permission_code,
+                exc,
+            )
+
+    action_label = _resolve_action_label(action) if action else None
+    risk_level = _infer_risk_level(method, action)
+
+    title = _build_title(
+        action_label=action_label or method,
+        menu_label=menu_label,
+        permission=permission,
+        operation_summary=summary,
+        method=method,
+        path=path,
+        permission_code=permission_code,
+    )
+
+    details = _extract_safe_details(
+        body=body,
+        path_params=path_params,
+        query_params=query_params,
+    )
+
+    # Infer target entity from path_params / 从路径参数推断目标实体
+    target: ApprovalTarget | None = None
+    if path_params:
+        first_key = next(iter(path_params))
+        target = ApprovalTarget(
+            type=first_key.replace("_id", "").replace("_", " "),
+            name=str(path_params[first_key]),
+        )
+
+    technical = {
+        "operation_id": operation_id,
+        "method": method,
+        "path": path,
+        "permission_code": permission_code,
+        "action": action,
+    }
+
+    return ToolApprovalPresentation(
+        title=title,
+        summary=summary or None,
+        risk_level=risk_level,
+        operation_type=method,
+        permission_code=permission_code,
+        menu_label=menu_label,
+        action_label=action_label,
+        target=target,
+        details=details,
+        technical=technical,
+    )
+
+
+__all__ = [
+    "ApprovalDetail",
+    "ApprovalTarget",
+    "ToolApprovalPresentation",
+    "build_approval_presentation",
+]

--- a/backend/app/ai/internal_ops/approval_presentation.py
+++ b/backend/app/ai/internal_ops/approval_presentation.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict, dataclass, field
-from typing import Any, Sequence
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -228,16 +228,18 @@ def _build_title(
     构建可读标题，带稳定兜底链。
 
     Priority:
-    1. action_label + menu_label (e.g. "创建 套餐管理")
-    2. translated permission name
+    1. translated permission leaf name (e.g. action.tenant_plan.create -> "创建套餐")
+    2. action_label + menu_label (e.g. "创建 套餐管理")
     3. operation summary
     4. method + path + permission_code
+
+    The business action name resolved from the permission leaf node takes
+    precedence so #46's acceptance copy ("创建套餐") is honored; the parent
+    menu ("套餐管理") stays available via ``menu_label``/``summary``.
     """
     if permission is not None:
         translated = PermissionPresentationDomain.translate_name(permission.name)
         if translated and translated != permission.name:
-            if action_label and menu_label:
-                return f"{action_label} {menu_label}"
             return translated
 
     if action_label and menu_label:

--- a/backend/app/ai/tools/executors/internal_api_executor.py
+++ b/backend/app/ai/tools/executors/internal_api_executor.py
@@ -349,6 +349,24 @@ class InternalApiExecutor(BaseToolExecutor):
                 }
             )
 
+        # Build user-readable approval presentation / 构建用户可读确认展示
+        from app.ai.internal_ops.approval_presentation import (
+            build_approval_presentation,
+        )
+
+        presentation = await build_approval_presentation(
+            db=context.db,
+            operation_id=op.operation_id,
+            method=op.method,
+            path=op.path,
+            permission_code=op.permission_code,
+            summary=op.summary,
+            action=op.action,
+            body=preview.get("body"),
+            path_params=preview.get("path_params"),
+            query_params=preview.get("query_params"),
+        )
+
         return _json_output(
             {
                 "requires_confirmation": True,
@@ -357,6 +375,7 @@ class InternalApiExecutor(BaseToolExecutor):
                 "summary": op.summary,
                 "permission": op.permission_code,
                 "preview": preview,
+                "approval_presentation": presentation.to_dict(),
                 "message": (
                     "This is a write operation and it was NOT executed yet. "
                     "Present the preview to the user and wait. If the user "

--- a/backend/app/services/ai/agent_chat_command_service.py
+++ b/backend/app/services/ai/agent_chat_command_service.py
@@ -86,6 +86,28 @@ def _build_rejection_message(interaction_updates: list[dict[str, Any]] | None) -
     return None
 
 
+def _build_rejection_chat_message(
+    message: str,
+    interaction_updates: list[dict[str, Any]] | None,
+) -> ChatMessage | None:
+    """Build an ``internal_only`` synthetic message for a cancelled approval.
+
+    Returns ``None`` when the user actually typed a message, or when there is
+    no pending-confirmation rejection.  The returned ``ChatMessage`` carries
+    ``internal_only=True`` so it is injected into the LLM context only — it is
+    never persisted as a real user message nor written to session memory.
+
+    返回的合成消息标记为 ``internal_only``，仅注入 LLM 上下文，不会作为真实
+    用户消息持久化，也不会写入 session memory。
+    """
+    if message:
+        return None
+    rejection_text = _build_rejection_message(interaction_updates)
+    if not rejection_text:
+        return None
+    return ChatMessage(role="user", content=rejection_text, internal_only=True)
+
+
 def _promote_safe_partial_output(result: Any) -> bool:
     if bool(getattr(result, "success", False)):
         return False
@@ -264,19 +286,22 @@ class AgentChatCommandService:
             max_tokens=ctx_cfg.get("max_history_tokens"),
         )
 
-        # Inject synthetic rejection message when user cancels an approval
-        # 用户取消授权确认卡片时，注入拒绝消息以避免 LLM 无输入异常
-        if not message:
-            rejection_msg = _build_rejection_message(interaction_updates)
-            if rejection_msg:
-                message = rejection_msg
-
         user_messages = build_user_messages(
             batch=None,
             message=message,
             attachments=attachments,
         )
         all_messages = merge_history_with_user_messages(history_messages, user_messages)
+
+        # When the user cancels an approval card the request carries an empty
+        # message + a rejection in interaction_updates. Inject the cancellation
+        # context as an internal_only synthetic message so the LLM can respond,
+        # while keeping `message`/`user_messages` empty so nothing is persisted
+        # as a real user message or written to session memory.
+        # 取消授权时仅注入 internal_only 合成消息供 LLM 使用，不持久化。
+        rejection_message = _build_rejection_chat_message(message, interaction_updates)
+        if rejection_message is not None:
+            all_messages = [*all_messages, rejection_message]
         hook_registry, all_messages = await run_before_agent_chat_hook(
             tenant_id=service.tenant_id,
             agent_id=agent_id,
@@ -520,14 +545,13 @@ class AgentChatCommandService:
         batch = [message] if message else []
         first_message = batch[0] if batch else ""
 
-        # Inject synthetic rejection message when user cancels an approval
-        # 用户取消授权确认卡片时，注入拒绝消息以避免 LLM 无输入异常
-        if not message and not batch:
-            rejection_msg = _build_rejection_message(interaction_updates)
-            if rejection_msg:
-                message = rejection_msg
-                batch = [message]
-                first_message = message
+        # When the user cancels an approval card the request carries an empty
+        # message + a rejection in interaction_updates. Build an internal_only
+        # synthetic message (injected below) so the LLM can acknowledge the
+        # cancellation, while keeping message/batch/user_msgs empty so it is
+        # never persisted as a real user message nor written to session memory.
+        # 取消授权时仅注入 internal_only 合成消息供 LLM 使用，不持久化。
+        rejection_message = _build_rejection_chat_message(message, interaction_updates)
 
         prepared_turn = await service.turn_orchestrator.prepare_conversation_turn(
             agent_id=agent_id,
@@ -562,6 +586,8 @@ class AgentChatCommandService:
             attachments=attachments,
         )
         all_messages = merge_history_with_user_messages(history_messages, user_msgs)
+        if rejection_message is not None:
+            all_messages = [*all_messages, rejection_message]
         hook_registry, all_messages = await run_before_agent_chat_hook(
             tenant_id=service.tenant_id,
             agent_id=agent_id,

--- a/backend/app/services/ai/agent_chat_command_service.py
+++ b/backend/app/services/ai/agent_chat_command_service.py
@@ -61,6 +61,31 @@ _SAFE_PARTIAL_OUTPUT_REASONS = frozenset(
 )
 
 
+def _build_rejection_message(interaction_updates: list[dict[str, Any]] | None) -> str | None:
+    """Build a synthetic user message when the user rejects a pending confirmation.
+
+    When a user clicks "cancel" on an approval card the frontend sends an empty
+    ``message`` together with ``interaction_updates`` containing a rejection.
+    Without a user message the LLM would have no new input and would fail with
+    "Tool selection completed without execution".  This helper builds a
+    minimal message so the LLM can acknowledge the cancellation.
+
+    当用户在授权确认卡片点击「取消」时，前端发送空消息 + rejection 的
+    ``interaction_updates``。 如果不注入消息，LLM 没有新输入会异常结束。
+    此辅助函数构建一条最小化消息让 LLM 确认取消。
+    """
+    if not interaction_updates:
+        return None
+    for update in interaction_updates:
+        if not isinstance(update, dict):
+            continue
+        if str(update.get("kind", "")) != "pending_confirmation":
+            continue
+        if bool(update.get("rejected")):
+            return "取消"
+    return None
+
+
 def _promote_safe_partial_output(result: Any) -> bool:
     if bool(getattr(result, "success", False)):
         return False
@@ -238,6 +263,13 @@ class AgentChatCommandService:
             max_messages=ctx_cfg.get("max_history_messages", 0),
             max_tokens=ctx_cfg.get("max_history_tokens"),
         )
+
+        # Inject synthetic rejection message when user cancels an approval
+        # 用户取消授权确认卡片时，注入拒绝消息以避免 LLM 无输入异常
+        if not message:
+            rejection_msg = _build_rejection_message(interaction_updates)
+            if rejection_msg:
+                message = rejection_msg
 
         user_messages = build_user_messages(
             batch=None,
@@ -487,6 +519,15 @@ class AgentChatCommandService:
 
         batch = [message] if message else []
         first_message = batch[0] if batch else ""
+
+        # Inject synthetic rejection message when user cancels an approval
+        # 用户取消授权确认卡片时，注入拒绝消息以避免 LLM 无输入异常
+        if not message and not batch:
+            rejection_msg = _build_rejection_message(interaction_updates)
+            if rejection_msg:
+                message = rejection_msg
+                batch = [message]
+                first_message = message
 
         prepared_turn = await service.turn_orchestrator.prepare_conversation_turn(
             agent_id=agent_id,

--- a/backend/tests/ai/internal_ops/test_approval_presentation.py
+++ b/backend/tests/ai/internal_ops/test_approval_presentation.py
@@ -1,0 +1,400 @@
+"""
+Issue #46: 基于 RBAC 生成 AI 内部工具操作确认展示数据
+Test type: behavioral
+Scope: build_approval_presentation, sensitive filtering, risk heuristics,
+       title fallback chain, technical detail inclusion.
+Real dependencies: build_approval_presentation, ToolApprovalPresentation.
+Mocked dependencies: AsyncSession via AsyncMock.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.ai.internal_ops.approval_presentation import (
+    ApprovalDetail,
+    ToolApprovalPresentation,
+    _extract_safe_details,
+    _format_detail_value,
+    _infer_risk_level,
+    _is_sensitive_key,
+    build_approval_presentation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sensitive key filtering / 敏感字段过滤
+# ---------------------------------------------------------------------------
+
+
+class TestSensitiveKeyFiltering:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "password",
+            "old_password",
+            "new_password",
+            "token",
+            "access_token",
+            "refresh_token",
+            "api_key",
+            "secret",
+            "secret_key",
+            "authorization",
+            "cookie",
+            "headers",
+            "private_key",
+            "credential",
+        ],
+    )
+    def test_sensitive_keys_detected(self, key: str) -> None:
+        assert _is_sensitive_key(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        ["name", "price", "billing_cycle", "status", "tenant_id", "email"],
+    )
+    def test_safe_keys_pass(self, key: str) -> None:
+        assert _is_sensitive_key(key) is False
+
+    def test_mixed_case_and_underscore_variants(self) -> None:
+        assert _is_sensitive_key("API_KEY") is True
+        assert _is_sensitive_key("Access-Token") is True
+        assert _is_sensitive_key("SECRET") is True
+
+
+# ---------------------------------------------------------------------------
+# Risk level heuristics / 风险等级
+# ---------------------------------------------------------------------------
+
+
+class TestRiskLevel:
+    def test_delete_is_high_risk(self) -> None:
+        assert _infer_risk_level("DELETE", "delete") == "high"
+
+    def test_disable_is_high_risk(self) -> None:
+        assert _infer_risk_level("POST", "disable") == "high"
+
+    def test_post_is_medium_risk(self) -> None:
+        assert _infer_risk_level("POST", "create") == "medium"
+
+    def test_patch_is_medium_risk(self) -> None:
+        assert _infer_risk_level("PATCH", "update") == "medium"
+
+    def test_get_is_low_risk(self) -> None:
+        assert _infer_risk_level("GET", "read") == "low"
+
+
+# ---------------------------------------------------------------------------
+# Safe detail extraction / 安全详情提取
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSafeDetails:
+    def test_body_fields_extracted(self) -> None:
+        body = {"name": "Pro Plan", "price": 99, "billing_cycle": "monthly"}
+        details = _extract_safe_details(
+            body=body, path_params={}, query_params={}
+        )
+        labels = [d.label for d in details]
+        assert "name" in labels
+        assert "price" in labels
+        assert "billing_cycle" in labels
+
+    def test_sensitive_body_fields_excluded(self) -> None:
+        body = {
+            "name": "Pro Plan",
+            "password": "hunter2",
+            "api_key": "sk-123",
+            "token": "abc",
+            "authorization": "Bearer xxx",
+        }
+        details = _extract_safe_details(
+            body=body, path_params={}, query_params={}
+        )
+        labels = [d.label for d in details]
+        assert "name" in labels
+        assert "password" not in labels
+        assert "api_key" not in labels
+        assert "token" not in labels
+        assert "authorization" not in labels
+
+    def test_path_params_included(self) -> None:
+        details = _extract_safe_details(
+            body=None,
+            path_params={"tenant_id": 42},
+            query_params={},
+        )
+        assert any(d.label == "tenant_id" and d.value == "42" for d in details)
+
+    def test_none_values_skipped(self) -> None:
+        body = {"name": "test", "description": None}
+        details = _extract_safe_details(
+            body=body, path_params={}, query_params={}
+        )
+        assert len(details) == 1
+        assert details[0].label == "name"
+
+    def test_max_fields_limit(self) -> None:
+        body = {f"field_{i}": f"val_{i}" for i in range(20)}
+        details = _extract_safe_details(
+            body=body, path_params={}, query_params={}, max_fields=5
+        )
+        assert len(details) == 5
+
+
+# ---------------------------------------------------------------------------
+# Value formatting / 值格式化
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetailValue:
+    def test_bool_true(self) -> None:
+        assert _format_detail_value(True) == "是"
+
+    def test_bool_false(self) -> None:
+        assert _format_detail_value(False) == "否"
+
+    def test_int(self) -> None:
+        assert _format_detail_value(42) == "42"
+
+    def test_string(self) -> None:
+        assert _format_detail_value("hello") == "hello"
+
+    def test_none_returns_empty(self) -> None:
+        assert _format_detail_value(None) == ""
+
+    def test_dict_returns_empty(self) -> None:
+        assert _format_detail_value({"a": 1}) == ""
+
+    def test_long_string_returns_empty(self) -> None:
+        assert _format_detail_value("x" * 300) == ""
+
+
+# ---------------------------------------------------------------------------
+# build_approval_presentation (async) / 异步构建函数
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_db(
+    *,
+    permission: SimpleNamespace | None = None,
+    parent_menu: SimpleNamespace | None = None,
+) -> AsyncMock:
+    """Build a mock AsyncSession that returns the given permission chain."""
+    db = AsyncMock()
+
+    if permission is None:
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        db.execute.return_value = result
+        return db
+
+    # First call: find permission by code
+    perm_result = MagicMock()
+    perm_result.scalar_one_or_none.return_value = permission
+
+    if parent_menu is not None:
+        # Second call: find parent menu
+        parent_result = MagicMock()
+        parent_result.scalar_one_or_none.return_value = parent_menu
+        db.execute.side_effect = [perm_result, parent_result]
+    else:
+        # Permission has no parent
+        no_parent_result = MagicMock()
+        no_parent_result.scalar_one_or_none.return_value = None
+        db.execute.side_effect = [perm_result, no_parent_result]
+
+    return db
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_with_permission_and_menu() -> None:
+    """Permission found + parent menu → title includes action + menu label."""
+    permission = SimpleNamespace(
+        id=100,
+        code="tenant_plan:create",
+        name="tenant.plan.create",
+        type="operation",
+        parent_id=50,
+    )
+    parent_menu = SimpleNamespace(
+        id=50,
+        code="menu:tenant.plan",
+        name="tenant.plan.title",
+        type="menu",
+        parent_id=None,
+    )
+    db = _make_mock_db(permission=permission, parent_menu=parent_menu)
+
+    presentation = await build_approval_presentation(
+        db=db,
+        operation_id="POST:/admin/plans",
+        method="POST",
+        path="/admin/plans",
+        permission_code="tenant_plan:create",
+        summary="Create a tenant plan",
+        action="create",
+        body={"name": "Pro", "price": 99, "billing_cycle": "monthly"},
+        path_params={},
+        query_params={},
+    )
+
+    assert isinstance(presentation, ToolApprovalPresentation)
+    assert presentation.risk_level == "medium"
+    assert presentation.permission_code == "tenant_plan:create"
+    assert presentation.operation_type == "POST"
+    # Technical details always present
+    assert presentation.technical["operation_id"] == "POST:/admin/plans"
+    assert presentation.technical["method"] == "POST"
+    # Safe business details extracted
+    labels = [d.label for d in presentation.details]
+    assert "name" in labels
+    assert "price" in labels
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_permission_not_found_fallback() -> None:
+    """Permission not found → fallback to summary or method+path+code."""
+    db = _make_mock_db(permission=None)
+
+    presentation = await build_approval_presentation(
+        db=db,
+        operation_id="POST:/admin/unknown",
+        method="POST",
+        path="/admin/unknown",
+        permission_code="unknown:action",
+        summary="Some operation summary",
+        action="action",
+        body={"name": "test"},
+        path_params={},
+        query_params={},
+    )
+
+    assert isinstance(presentation, ToolApprovalPresentation)
+    # Title should fall back to summary
+    assert presentation.title == "Some operation summary"
+    assert presentation.permission_code == "unknown:action"
+    assert presentation.menu_label is None
+    # Technical details still present
+    assert presentation.technical["permission_code"] == "unknown:action"
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_no_db() -> None:
+    """db=None → no crash, pure fallback behavior."""
+    presentation = await build_approval_presentation(
+        db=None,
+        operation_id="DELETE:/admin/tenants/{tenant_id}",
+        method="DELETE",
+        path="/admin/tenants/{tenant_id}",
+        permission_code="tenant:delete",
+        summary="Delete a tenant",
+        action="delete",
+        body=None,
+        path_params={"tenant_id": 5},
+        query_params={},
+    )
+
+    assert isinstance(presentation, ToolApprovalPresentation)
+    assert presentation.risk_level == "high"
+    assert presentation.title == "Delete a tenant"
+    # target inferred from path_params
+    assert presentation.target is not None
+    assert presentation.target.type == "tenant"
+    assert presentation.target.name == "5"
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_sensitive_fields_not_in_output() -> None:
+    """password, token, api_key etc must NOT appear in details or to_dict()."""
+    db = _make_mock_db(permission=None)
+
+    presentation = await build_approval_presentation(
+        db=db,
+        operation_id="POST:/admin/users",
+        method="POST",
+        path="/admin/users",
+        permission_code="user:create",
+        summary="Create user",
+        action="create",
+        body={
+            "name": "Alice",
+            "email": "alice@example.com",
+            "password": "super_secret_123",
+            "api_key": "sk-abc123",
+            "token": "eyJ...",
+            "authorization": "Bearer xyz",
+            "cookie": "session=abc",
+            "headers": {"X-Custom": "val"},
+        },
+        path_params={},
+        query_params={},
+    )
+
+    output = presentation.to_dict()
+    output_str = str(output)
+    # Sensitive values must not leak
+    assert "super_secret_123" not in output_str
+    assert "sk-abc123" not in output_str
+    assert "eyJ..." not in output_str
+    # Safe fields present
+    labels = [d["label"] for d in output.get("details", [])]
+    assert "name" in labels
+    assert "email" in labels
+    assert "password" not in labels
+
+
+@pytest.mark.asyncio
+async def test_build_presentation_db_error_graceful() -> None:
+    """DB query failure → graceful degradation, no crash."""
+    db = AsyncMock()
+    db.execute.side_effect = RuntimeError("connection lost")
+
+    presentation = await build_approval_presentation(
+        db=db,
+        operation_id="POST:/admin/plans",
+        method="POST",
+        path="/admin/plans",
+        permission_code="tenant_plan:create",
+        summary="Create plan",
+        action="create",
+        body={"name": "Basic"},
+        path_params={},
+        query_params={},
+    )
+
+    assert isinstance(presentation, ToolApprovalPresentation)
+    # Fallback title should be summary
+    assert presentation.title == "Create plan"
+    assert presentation.menu_label is None
+
+
+# ---------------------------------------------------------------------------
+# ToolApprovalPresentation.to_dict() / 序列化
+# ---------------------------------------------------------------------------
+
+
+class TestToDict:
+    def test_none_fields_excluded(self) -> None:
+        p = ToolApprovalPresentation(title="Test", summary=None, menu_label=None)
+        d = p.to_dict()
+        assert "summary" not in d
+        assert "menu_label" not in d
+        assert d["title"] == "Test"
+
+    def test_empty_details_excluded(self) -> None:
+        p = ToolApprovalPresentation(title="Test", details=[])
+        d = p.to_dict()
+        assert "details" not in d
+
+    def test_technical_included(self) -> None:
+        p = ToolApprovalPresentation(
+            title="Test",
+            technical={"operation_id": "POST:/admin/x"},
+        )
+        d = p.to_dict()
+        assert d["technical"]["operation_id"] == "POST:/admin/x"

--- a/backend/tests/ai/internal_ops/test_approval_presentation.py
+++ b/backend/tests/ai/internal_ops/test_approval_presentation.py
@@ -398,3 +398,44 @@ class TestToDict:
         )
         d = p.to_dict()
         assert d["technical"]["operation_id"] == "POST:/admin/x"
+
+
+# ---------------------------------------------------------------------------
+# build_pending_confirmation_payload pass-through / 透传测试
+# ---------------------------------------------------------------------------
+
+
+class TestPendingConfirmationPassthrough:
+    """Verify approval_presentation is forwarded in the SSE metadata."""
+
+    def test_approval_presentation_passed_through(self) -> None:
+        from app.ai.engine.tool_processor_messages import (
+            build_pending_confirmation_payload,
+        )
+
+        parsed = {
+            "requires_confirmation": True,
+            "action": "POST /admin/plans",
+            "preview": {"body": {"name": "Pro"}},
+            "approval_presentation": {
+                "title": "创建 套餐管理",
+                "risk_level": "medium",
+            },
+        }
+        payload = build_pending_confirmation_payload(parsed, "invoke_internal_operation")
+        assert "approval_presentation" in payload
+        assert payload["approval_presentation"]["title"] == "创建 套餐管理"
+        assert payload["approval_presentation"]["risk_level"] == "medium"
+
+    def test_no_approval_presentation_no_key(self) -> None:
+        from app.ai.engine.tool_processor_messages import (
+            build_pending_confirmation_payload,
+        )
+
+        parsed = {
+            "requires_confirmation": True,
+            "action": "POST /admin/x",
+            "preview": {},
+        }
+        payload = build_pending_confirmation_payload(parsed, "some_tool")
+        assert "approval_presentation" not in payload

--- a/backend/tests/ai/internal_ops/test_approval_presentation.py
+++ b/backend/tests/ai/internal_ops/test_approval_presentation.py
@@ -15,7 +15,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.ai.internal_ops.approval_presentation import (
-    ApprovalDetail,
     ToolApprovalPresentation,
     _extract_safe_details,
     _format_detail_value,
@@ -23,7 +22,6 @@ from app.ai.internal_ops.approval_presentation import (
     _is_sensitive_key,
     build_approval_presentation,
 )
-
 
 # ---------------------------------------------------------------------------
 # Sensitive key filtering / 敏感字段过滤
@@ -257,6 +255,52 @@ async def test_build_presentation_with_permission_and_menu() -> None:
 
 
 @pytest.mark.asyncio
+async def test_build_presentation_title_uses_permission_leaf_translation() -> None:
+    """#46 acceptance: POST /admin/plans + tenant_plan:create -> title "创建套餐".
+
+    The business action name translated from the permission leaf node
+    (``action.tenant_plan.create`` -> "创建套餐") must take precedence over the
+    "{action} {menu}" composition ("创建 套餐管理"); the parent menu stays in
+    ``menu_label``.
+    """
+    permission = SimpleNamespace(
+        id=100,
+        code="tenant_plan:create",
+        name="action.tenant_plan.create",  # real i18n key -> "创建套餐"
+        type="operation",
+        parent_id=50,
+    )
+    parent_menu = SimpleNamespace(
+        id=50,
+        code="menu:tenant.plan",
+        name="menu.admin.tenant_plan",  # real i18n key -> "套餐管理"
+        type="menu",
+        parent_id=None,
+    )
+    db = _make_mock_db(permission=permission, parent_menu=parent_menu)
+
+    presentation = await build_approval_presentation(
+        db=db,
+        operation_id="POST:/admin/plans",
+        method="POST",
+        path="/admin/plans",
+        permission_code="tenant_plan:create",
+        summary="Create a tenant plan",
+        action="create",
+        body={"name": "Pro"},
+        path_params={},
+        query_params={},
+    )
+
+    # Title is the translated leaf action name, NOT "创建 套餐管理"
+    assert presentation.title == "创建套餐"
+    assert presentation.title != "创建 套餐管理"
+    # Parent menu remains available for the card subtitle
+    assert presentation.menu_label == "套餐管理"
+    assert presentation.action_label == "创建"
+
+
+@pytest.mark.asyncio
 async def test_build_presentation_permission_not_found_fallback() -> None:
     """Permission not found → fallback to summary or method+path+code."""
     db = _make_mock_db(permission=None)
@@ -418,13 +462,13 @@ class TestPendingConfirmationPassthrough:
             "action": "POST /admin/plans",
             "preview": {"body": {"name": "Pro"}},
             "approval_presentation": {
-                "title": "创建 套餐管理",
+                "title": "创建套餐",
                 "risk_level": "medium",
             },
         }
         payload = build_pending_confirmation_payload(parsed, "invoke_internal_operation")
         assert "approval_presentation" in payload
-        assert payload["approval_presentation"]["title"] == "创建 套餐管理"
+        assert payload["approval_presentation"]["title"] == "创建套餐"
         assert payload["approval_presentation"]["risk_level"] == "medium"
 
     def test_no_approval_presentation_no_key(self) -> None:
@@ -457,7 +501,7 @@ class TestConfirmationEventPassthrough:
             "action": "POST /admin/plans",
             "preview": {"body": {"name": "Pro"}},
             "approval_presentation": {
-                "title": "创建 套餐管理",
+                "title": "创建套餐",
                 "risk_level": "medium",
                 "summary": "AI 助手将执行「套餐管理」下的「创建套餐」操作。",
             },
@@ -465,7 +509,7 @@ class TestConfirmationEventPassthrough:
         event = build_confirmation_event(parsed, "invoke_internal_operation")
         assert event["event"] == "confirmation_request"
         assert "approval_presentation" in event
-        assert event["approval_presentation"]["title"] == "创建 套餐管理"
+        assert event["approval_presentation"]["title"] == "创建套餐"
         assert event["approval_presentation"]["risk_level"] == "medium"
 
     def test_no_approval_presentation_in_sse_event(self) -> None:

--- a/backend/tests/ai/internal_ops/test_approval_presentation.py
+++ b/backend/tests/ai/internal_ops/test_approval_presentation.py
@@ -439,3 +439,43 @@ class TestPendingConfirmationPassthrough:
         }
         payload = build_pending_confirmation_payload(parsed, "some_tool")
         assert "approval_presentation" not in payload
+
+
+# ---------------------------------------------------------------------------
+# build_confirmation_event pass-through / SSE 事件透传测试
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmationEventPassthrough:
+    """Verify approval_presentation is included in the confirmation_request SSE event."""
+
+    def test_approval_presentation_in_sse_event(self) -> None:
+        from app.ai.engine.tool_processor_events import build_confirmation_event
+
+        parsed = {
+            "requires_confirmation": True,
+            "action": "POST /admin/plans",
+            "preview": {"body": {"name": "Pro"}},
+            "approval_presentation": {
+                "title": "创建 套餐管理",
+                "risk_level": "medium",
+                "summary": "AI 助手将执行「套餐管理」下的「创建套餐」操作。",
+            },
+        }
+        event = build_confirmation_event(parsed, "invoke_internal_operation")
+        assert event["event"] == "confirmation_request"
+        assert "approval_presentation" in event
+        assert event["approval_presentation"]["title"] == "创建 套餐管理"
+        assert event["approval_presentation"]["risk_level"] == "medium"
+
+    def test_no_approval_presentation_in_sse_event(self) -> None:
+        from app.ai.engine.tool_processor_events import build_confirmation_event
+
+        parsed = {
+            "requires_confirmation": True,
+            "action": "POST /admin/x",
+            "preview": {},
+        }
+        event = build_confirmation_event(parsed, "some_tool")
+        assert event["event"] == "confirmation_request"
+        assert "approval_presentation" not in event

--- a/backend/tests/ai/internal_ops/test_rejection_message.py
+++ b/backend/tests/ai/internal_ops/test_rejection_message.py
@@ -70,3 +70,101 @@ class TestBuildRejectionMessage:
         updates: list = ["not_a_dict", {"kind": "pending_confirmation", "rejected": True}]
         result = _build_rejection_message(updates)
         assert result == "取消"
+
+
+# ---------------------------------------------------------------------------
+# Rejection shortcircuit in plan_execution_tools / 拒绝短路测试
+# ---------------------------------------------------------------------------
+
+
+class TestRejectionShortcircuit:
+    """Verify plan_execution_tools returns a direct_reply plan when rejection is detected."""
+
+    def _build_request_with_rejection(self):
+        from app.ai.engine.types import ExecutionRequest
+
+        return ExecutionRequest(
+            agent_id=1,
+            tenant_id=0,
+            messages=[],
+            interaction_updates=[
+                {
+                    "kind": "pending_confirmation",
+                    "rejected": True,
+                    "tool_name": "invoke_internal_operation",
+                }
+            ],
+        )
+
+    def test_rejection_returns_direct_reply_no_tools(self) -> None:
+        from types import SimpleNamespace
+
+        from app.ai.engine.prepare_execution_tool_helpers import plan_execution_tools
+
+        request = self._build_request_with_rejection()
+        tools = [
+            SimpleNamespace(
+                name="invoke_internal_operation",
+                description="Internal ops tool",
+                semantic_family="internal_ops",
+                semantic_tags=[],
+            )
+        ]
+        messages = [SimpleNamespace(role="user", content="取消")]
+        diagnostics: dict = {"intent_plan": []}
+
+        plan = plan_execution_tools(
+            agent_id=1,
+            conversation_id=100,
+            request=request,
+            messages=messages,  # type: ignore[arg-type]
+            tools=list(tools),
+            all_tools=list(tools),
+            diagnostics=diagnostics,
+        )
+
+        assert plan.tools == []
+        assert plan.candidate_tool_names == []
+        assert plan.tool_planner["reason"] == "rejection_shortcircuit"
+        assert plan.intent_plan[0].kind == "direct_reply"
+        assert plan.intent_plan[0].requires_tools is False
+        assert plan.tool_use_policy.reason == "confirmation_rejection"
+
+    def test_no_rejection_does_not_shortcircuit(self) -> None:
+        from types import SimpleNamespace
+
+        from app.ai.engine.prepare_execution_tool_helpers import plan_execution_tools
+        from app.ai.engine.types import ExecutionRequest
+
+        request = ExecutionRequest(
+            agent_id=1,
+            tenant_id=0,
+            messages=[],
+            interaction_updates=[
+                {"kind": "pending_confirmation", "rejected": False}
+            ],
+        )
+        tools = [
+            SimpleNamespace(
+                name="invoke_internal_operation",
+                description="Internal ops tool",
+                semantic_family="internal_ops",
+                semantic_tags=[],
+            )
+        ]
+        messages = [SimpleNamespace(role="user", content="确认")]
+        diagnostics: dict = {"intent_plan": []}
+
+        plan = plan_execution_tools(
+            agent_id=1,
+            conversation_id=101,
+            request=request,
+            messages=messages,  # type: ignore[arg-type]
+            tools=list(tools),
+            all_tools=list(tools),
+            diagnostics=diagnostics,
+        )
+
+        # Non-rejection should not trigger the rejection shortcircuit
+        if plan.tool_planner is not None:
+            assert plan.tool_planner.get("reason") != "rejection_shortcircuit"

--- a/backend/tests/ai/internal_ops/test_rejection_message.py
+++ b/backend/tests/ai/internal_ops/test_rejection_message.py
@@ -1,0 +1,72 @@
+"""Unit tests for _build_rejection_message helper.
+
+验证用户取消授权确认卡片时，后端正确注入拒绝消息。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestBuildRejectionMessage:
+    """Test the _build_rejection_message helper function."""
+
+    def test_returns_none_when_updates_is_none(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        assert _build_rejection_message(None) is None
+
+    def test_returns_none_when_updates_is_empty(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        assert _build_rejection_message([]) is None
+
+    def test_returns_none_when_no_rejection(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates = [{"kind": "pending_confirmation", "rejected": False}]
+        assert _build_rejection_message(updates) is None
+
+    def test_returns_message_on_rejection(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates = [{"kind": "pending_confirmation", "rejected": True}]
+        result = _build_rejection_message(updates)
+        assert result == "取消"
+
+    def test_returns_message_on_rejection_with_tool_name(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates = [
+            {
+                "kind": "pending_confirmation",
+                "rejected": True,
+                "tool_name": "invoke_internal_operation",
+            }
+        ]
+        result = _build_rejection_message(updates)
+        assert result == "取消"
+
+    def test_ignores_non_confirmation_updates(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates = [{"kind": "other_kind", "rejected": True}]
+        assert _build_rejection_message(updates) is None
+
+    def test_handles_mixed_updates(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates = [
+            {"kind": "other_kind", "rejected": True},
+            {"kind": "pending_confirmation", "rejected": False},
+            {"kind": "pending_confirmation", "rejected": True},
+        ]
+        result = _build_rejection_message(updates)
+        assert result == "取消"
+
+    def test_handles_non_dict_updates(self) -> None:
+        from app.services.ai.agent_chat_command_service import _build_rejection_message
+
+        updates: list = ["not_a_dict", {"kind": "pending_confirmation", "rejected": True}]
+        result = _build_rejection_message(updates)
+        assert result == "取消"

--- a/backend/tests/ai/internal_ops/test_rejection_message.py
+++ b/backend/tests/ai/internal_ops/test_rejection_message.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 
 class TestBuildRejectionMessage:
     """Test the _build_rejection_message helper function."""
@@ -70,6 +68,88 @@ class TestBuildRejectionMessage:
         updates: list = ["not_a_dict", {"kind": "pending_confirmation", "rejected": True}]
         result = _build_rejection_message(updates)
         assert result == "取消"
+
+
+class TestBuildRejectionChatMessage:
+    """Test the _build_rejection_chat_message helper.
+
+    The synthetic cancellation message must be ``internal_only`` so it reaches
+    the LLM but is never persisted as a real user message or written to memory.
+    """
+
+    def test_returns_none_when_message_present(self) -> None:
+        from app.services.ai.agent_chat_command_service import (
+            _build_rejection_chat_message,
+        )
+
+        updates = [{"kind": "pending_confirmation", "rejected": True}]
+        # A real user message means no synthetic injection.
+        assert _build_rejection_chat_message("你好", updates) is None
+
+    def test_returns_none_when_no_rejection(self) -> None:
+        from app.services.ai.agent_chat_command_service import (
+            _build_rejection_chat_message,
+        )
+
+        updates = [{"kind": "pending_confirmation", "rejected": False}]
+        assert _build_rejection_chat_message("", updates) is None
+
+    def test_returns_none_when_updates_empty(self) -> None:
+        from app.services.ai.agent_chat_command_service import (
+            _build_rejection_chat_message,
+        )
+
+        assert _build_rejection_chat_message("", None) is None
+        assert _build_rejection_chat_message("", []) is None
+
+    def test_returns_internal_only_message_on_rejection(self) -> None:
+        from app.ai.types import ChatMessage
+        from app.services.ai.agent_chat_command_service import (
+            _build_rejection_chat_message,
+        )
+
+        updates = [{"kind": "pending_confirmation", "rejected": True}]
+        msg = _build_rejection_chat_message("", updates)
+
+        assert isinstance(msg, ChatMessage)
+        assert msg.role == "user"
+        assert msg.content == "取消"
+        # Critical: must be internal_only so persistence layer skips it.
+        assert msg.internal_only is True
+
+    def test_synthetic_message_is_filtered_by_persistence(self) -> None:
+        """An internal_only synthetic user message is dropped by persistence."""
+        from app.services.ai.agent_chat_command_service import (
+            _build_rejection_chat_message,
+        )
+        from app.services.ai.conversation_message_persistence_service import (
+            ConversationMessagePersistenceService,
+        )
+
+        updates = [{"kind": "pending_confirmation", "rejected": True}]
+        synthetic = _build_rejection_chat_message("", updates)
+        assert synthetic is not None
+
+        # Simulate engine echoing the synthetic message back in result.messages
+        # (asdict-style dict carrying the internal_only flag).
+        result_messages = [
+            {"role": "user", "content": "之前的真实消息"},
+            {"role": "user", "content": synthetic.content, "internal_only": True},
+            {"role": "assistant", "content": "好的，已取消该操作。"},
+        ]
+        new_start = ConversationMessagePersistenceService.resolve_new_message_start(
+            result_messages=result_messages,
+            history_count=1,
+        )
+        new_messages_raw = result_messages[new_start:]
+        # The synthetic (internal_only) user message must not survive into the
+        # persisted user content.
+        persisted_user_contents = [
+            m.get("content")
+            for m in new_messages_raw
+            if m.get("role") == "user" and not m.get("internal_only")
+        ]
+        assert "取消" not in persisted_user_contents
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #46

## 变更内容

### 新增模块

`backend/app/ai/internal_ops/approval_presentation.py`

基于 RBAC 权限树为 `invoke_internal_operation` 写确认生成 `ToolApprovalPresentation` 数据结构，供前端确认卡片渲染。

**核心能力：**
- 以 `permission_code` 为主线查询 `permissions` 表
- 向上遍历父级菜单/功能权限，生成业务归属（如"套餐管理"）
- 复用 `PermissionPresentationDomain.translate_name()` 实现多语言翻译
- 从 body/path_params/query_params 中提取安全业务字段
- 敏感字段（password/token/api_key/secret/authorization/cookie/headers）完全过滤
- 不额外调用 LLM，不增加 token 消耗
- 权限码查不到时稳定兜底：路由 summary → `method + path + permission_code`

### 集成

`internal_api_executor.py` 的 `_write_confirmation_gate` 输出新增 `approval_presentation` 字段，前端确认卡片可直接使用。

### 数据结构

```json
{
  "title": "创建 套餐管理",
  "risk_level": "medium",
  "permission_code": "tenant_plan:create",
  "menu_label": "套餐管理",
  "action_label": "创建",
  "details": [
    {"label": "name", "value": "Pro Plan"},
    {"label": "price", "value": "99"}
  ],
  "technical": {
    "operation_id": "POST:/admin/plans",
    "method": "POST",
    "path": "/admin/plans"
  }
}
```

### 测试

新增 46 个单元测试（`tests/ai/internal_ops/test_approval_presentation.py`），覆盖：
- 敏感字段过滤（password/token/api_key/secret/authorization/cookie/headers/private_key）
- 风险等级启发式判定
- 权限命中 + 父菜单解析
- 权限缺失兜底
- 无 DB 场景降级
- DB 异常优雅降级
- to_dict() 序列化