### PR TITLE
refactor(frontend): 技能包 code-defined builtin 展示优化（i18n + 复用后端工具）

### DIFF
--- a/frontend/apps/web-antd/src/locales/langs/en-US/admin/ai.json
+++ b/frontend/apps/web-antd/src/locales/langs/en-US/admin/ai.json
@@ -1373,6 +1373,7 @@
     "title": "Skill Management",
     "pageDesc": "Manage platform-wide skills including HTTP, email, code, knowledge base and more.",
     "system": "System",
+    "codeDefined": "Code-defined",
     "name": "Skill Name",
     "description": "Description",
     "avatar": "Icon",

--- a/frontend/apps/web-antd/src/locales/langs/zh-CN/admin/ai.json
+++ b/frontend/apps/web-antd/src/locales/langs/zh-CN/admin/ai.json
@@ -1373,6 +1373,7 @@
     "title": "技能管理",
     "pageDesc": "管理全平台技能，支持 HTTP、邮件、代码、知识库等多种技能类型。",
     "system": "系统",
+    "codeDefined": "代码定义",
     "name": "技能名称",
     "description": "描述",
     "avatar": "图标",

--- a/frontend/apps/web-antd/src/views/admin/ai/skill-packages/modules/SkillPackageSkillsTable.vue
+++ b/frontend/apps/web-antd/src/views/admin/ai/skill-packages/modules/SkillPackageSkillsTable.vue
@@ -123,7 +123,7 @@ function isRuntimeActiveSkill(record: AdminSkillInfo): boolean {
           class="ml-1"
           style="padding: 0 4px; font-size: 10px; line-height: 16px"
         >
-          code-defined
+          {{ $t('admin.ai.skill.codeDefined') }}
         </Tag>
       </template>
 

--- a/frontend/apps/web-antd/src/views/admin/ai/skills/modules/SkillFormContent.vue
+++ b/frontend/apps/web-antd/src/views/admin/ai/skills/modules/SkillFormContent.vue
@@ -51,6 +51,21 @@ async function loadPluginTools(skillId: number) {
   }
 }
 
+// 代码定义型 builtin（如 internal_ops）的工具在后端代码中，复用解析接口拉取。
+// Code-defined builtin tools (e.g. internal_ops) live in backend code; fetch
+// them from the resolved-tools endpoint instead of hardcoding on the frontend.
+async function loadBuiltinTools(skillId: number) {
+  try {
+    const tools = await getSkillToolsApi(skillId);
+    builtinTools.value = tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+    }));
+  } catch {
+    builtinTools.value = [];
+  }
+}
+
 const { Drawer, isEdit } = useCrudDrawer<AdminSkillInfo>({
   formApi,
   schema: getSchema,
@@ -61,6 +76,7 @@ const { Drawer, isEdit } = useCrudDrawer<AdminSkillInfo>({
     toSkillFormValues(data, {
       ...sharedState,
       loadPluginTools,
+      loadBuiltinTools,
     }),
   onSuccess: () => {
     emits('success');

--- a/frontend/apps/web-antd/src/views/admin/ai/skills/modules/skill-form-values.ts
+++ b/frontend/apps/web-antd/src/views/admin/ai/skills/modules/skill-form-values.ts
@@ -4,6 +4,7 @@ import type { AdminSkillInfo } from '#/api/admin/skills';
 
 interface SkillFormValueOptions extends SkillFormSharedState {
   loadPluginTools?: (skillId: number) => void;
+  loadBuiltinTools?: (skillId: number) => void;
 }
 
 export function getSkillFormDefaults(
@@ -161,35 +162,6 @@ export function buildSkillFormPayload(values: Record<string, unknown>) {
 
 export const transformSkillFormValues = buildSkillFormPayload;
 
-/**
- * Build synthetic BuiltinToolInfo entries for code-defined builtin types.
- * These tools live in backend code, not in config.tools.
- */
-function getCodeDefinedBuiltinTools(
-  builtinType: string,
-): BuiltinToolInfo[] {
-  if (builtinType === 'internal_ops') {
-    return [
-      {
-        name: 'list_internal_operations',
-        description:
-          'Search the management-console operation catalog available to the current user.',
-      },
-      {
-        name: 'describe_internal_operation',
-        description:
-          'Get the full parameter specification of one internal operation.',
-      },
-      {
-        name: 'invoke_internal_operation',
-        description:
-          'Invoke one internal operation on behalf of the current user.',
-      },
-    ];
-  }
-  return [];
-}
-
 export function toSkillFormValues(
   data: AdminSkillInfo,
   options: SkillFormValueOptions,
@@ -204,11 +176,17 @@ export function toSkillFormValues(
     options.builtinTools.value = cfg.tools as BuiltinToolInfo[];
   } else if (
     // 代码定义型 builtin / code-defined builtin (e.g. internal_ops)
+    // 工具定义存在于后端代码而非 config.tools，复用后端解析结果避免前端漂移。
+    // Tool definitions live in backend code, not config.tools; reuse the
+    // backend-resolved tools to avoid frontend drift.
     data.type === 'builtin' &&
     typeof cfg.builtin_type === 'string' &&
     cfg.builtin_type
   ) {
-    options.builtinTools.value = getCodeDefinedBuiltinTools(cfg.builtin_type);
+    options.builtinTools.value = [];
+    if (typeof data.id === 'number' && options.loadBuiltinTools) {
+      options.loadBuiltinTools(data.id);
+    }
   } else {
     options.builtinTools.value = [];
   }

--- a/frontend/apps/web-antd/src/views/admin/ai/skills/modules/use-skill-form-shell.ts
+++ b/frontend/apps/web-antd/src/views/admin/ai/skills/modules/use-skill-form-shell.ts
@@ -5,7 +5,7 @@ import type { AdminSkillInfo, PluginToolDefinition } from '#/api/admin/skills';
 import { computed, ref, watch } from 'vue';
 
 import { useVbenForm } from '#/adapter/form';
-import { getSkillDetailApi } from '#/api/admin/skills';
+import { getSkillDetailApi, getSkillToolsApi } from '#/api/admin/skills';
 import { useCrudDrawer } from '#/composables';
 import { $t } from '#/locales';
 
@@ -35,6 +35,29 @@ export function useSkillFormShell(options: UseSkillFormShellOptions) {
     pluginTools,
   };
 
+  async function loadPluginTools(skillId: number) {
+    try {
+      pluginTools.value = await getSkillToolsApi(skillId);
+    } catch {
+      pluginTools.value = [];
+    }
+  }
+
+  // 代码定义型 builtin 工具在后端代码中，复用解析接口拉取。
+  // Code-defined builtin tools live in backend code; fetch from the
+  // resolved-tools endpoint instead of hardcoding on the frontend.
+  async function loadBuiltinTools(skillId: number) {
+    try {
+      const tools = await getSkillToolsApi(skillId);
+      builtinTools.value = tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+      }));
+    } catch {
+      builtinTools.value = [];
+    }
+  }
+
   const useFormSchema = createSkillFormSchema(sharedState);
   const [Form, formApi] = useVbenForm({
     schema: useFormSchema(),
@@ -47,7 +70,12 @@ export function useSkillFormShell(options: UseSkillFormShellOptions) {
     defaults: () => getSkillFormDefaults(sharedState),
     apiPath: '/admin/ai/skills',
     transform: transformSkillFormValues,
-    toFormValues: (data) => toSkillFormValues(data, sharedState),
+    toFormValues: (data) =>
+      toSkillFormValues(data, {
+        ...sharedState,
+        loadPluginTools,
+        loadBuiltinTools,
+      }),
     onSuccess: options.onSuccess,
     detailApi: async (id) => await getSkillDetailApi(id as number),
   });


### PR DESCRIPTION
Fixes #44

## 背景

PR #43 审查者提出两个非阻塞建议，本 PR 落地：消除 `code-defined` 文案硬编码与前端工具定义硬编码。

## 变更内容

### 1. code-defined 文案走 i18n
- 新增翻译键 `admin.ai.skill.codeDefined`（`en-US`: `Code-defined` / `zh-CN`: `代码定义`）。
- `SkillPackageSkillsTable.vue` 用 `$t('admin.ai.skill.codeDefined')` 替换硬编码 `code-defined`，中文界面不再混入英文。

### 2. 复用后端 resolved tools，消除前后端硬编码漂移
- 删除 `skill-form-values.ts` 中硬编码的 `getCodeDefinedBuiltinTools()`（写死了 internal_ops 的 3 个工具名与描述）。
- 代码定义型 builtin 分支改为调用新增的 `loadBuiltinTools(skillId)` 回调，复用后端 `getSkillToolsApi`（`/admin/ai/skills/{id}/tools`，底层走 `SkillResolver.resolve`）返回的实际工具定义。
- `SkillFormContent.vue`（活跃路径）与 `use-skill-form-shell.ts` 接入 `loadBuiltinTools`，沿用既有 `loadPluginTools` 异步加载模式，保持 `toSkillFormValues` 同步签名。

## 说明
- `use-skill-form-shell.ts` 排查发现当前未被任何地方 import（活跃路径为 `SkillFormShell.vue → SkillFormContent.vue`），本 PR 仍同步为其补齐回调以保持行为一致；其用途与是否清理另开 Issue 跟踪。

## 验收标准
- [x] 技能列表 code-defined 标签随界面语言切换
- [x] 编辑 internal_ops 技能时工具列表来自后端解析结果，不再前端硬编码
- [x] 后端工具增删改名时前端展示自动跟随
- [x] 改动文件无 lint/类型错误，i18n JSON 合法

## 测试计划
- [ ] 管理端打开「运营 Copilot」类 internal_ops 技能编辑抽屉，确认工具面板显示 3 个元工具且描述来自后端
- [ ] 切换中/英文，确认技能列表 code-defined 标签文案随之切换

Made with [Cursor](https://cursor.com)