### PR TITLE
perf(deploy): Nginx 补充通用静态资源缓存头配置

### DIFF
--- a/frontend/scripts/deploy/nginx.conf
+++ b/frontend/scripts/deploy/nginx.conf
@@ -57,11 +57,18 @@ http {
       index index.html;
     }
 
-    # 静态资源长缓存（带 hash 的文件可安全缓存 1 年）
+    # 静态资源长缓存（Vite 产物带 hash，可安全缓存 1 年）
     location /assets/ {
       root /usr/share/nginx/html;
       expires 365d;
       add_header Cache-Control "public, immutable";
+    }
+
+    # 图标与字体资源
+    location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot)$ {
+      root /usr/share/nginx/html;
+      expires 30d;
+      add_header Cache-Control "public";
     }
 
     error_page 500 502 503 504 /50x.html;


### PR DESCRIPTION
## 变更说明

当前 `frontend/scripts/deploy/nginx.conf` 仅对 `/assets/` 路径配置了长缓存头，但 SPA 中的图标、图片、字体等静态资源不在该路径下，缺少 `Cache-Control` 响应头，导致 Cloudflare CDN 和浏览器无法有效缓存，每次访问均需回源。

### 改动内容

在 `nginx.conf` 的 `server` 块中新增一个 `location` 规则，匹配常见静态资源扩展名：

```nginx
location ~* \.(ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot)$ {
    root /usr/share/nginx/html;
    expires 30d;
    add_header Cache-Control "public";
}
```

### 预期效果

- Cloudflare CDN 和浏览器可缓存图标、图片、字体等资源（30 天）
- 减少回源请求数，优化二次访问体验
- 配合已有的 Cloudflare Cache Rule 进一步提升国内用户访问速度

Fixes #59