### PR TITLE
fix(deploy): Dockerfile 保留 .env.production 原有构建配置

### DIFF
--- a/frontend/scripts/deploy/Dockerfile
+++ b/frontend/scripts/deploy/Dockerfile
@@ -27,8 +27,8 @@ COPY VERSION /
 COPY backend/app /backend/app
 COPY backend/plugins /backend/plugins
 
-# Write VITE_GLOB_* env vars into .env.production so the runtime _app.config.js picks them up
-RUN printf 'VITE_GLOB_API_URL=%s\n' "$VITE_GLOB_API_URL" > /app/apps/web-antd/.env.production
+# Override VITE_GLOB_API_URL in .env.production (keep other build-time vars intact)
+RUN sed -i "s|^VITE_GLOB_API_URL=.*|VITE_GLOB_API_URL=$VITE_GLOB_API_URL|" /app/apps/web-antd/.env.production
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm --filter @vben/web-antd... build


### PR DESCRIPTION
## 问题

当前 Dockerfile builder 阶段第 31 行：

```dockerfile
RUN printf 'VITE_GLOB_API_URL=%s\n' "$VITE_GLOB_API_URL" > /app/apps/web-antd/.env.production
```

用 `>` **覆写了整个** `.env.production` 文件，导致：
- `VITE_INJECT_APP_LOADING=true` 被冲掉 → 生产构建未注入全局加载动画
- `VITE_PWA`、`VITE_ROUTER_HISTORY`、`VITE_ARCHIVER` 等配置也一并丢失

生产站点 `demo.nvuai.cc` 的 HTML 中完全没有 `#__app-loading__` 元素，用户打开时直接黑屏等待。

## 修复

改为 `sed` 原地替换 `VITE_GLOB_API_URL` 行，保留 `.env.production` 其他所有配置：

```dockerfile
RUN sed -i "s|^VITE_GLOB_API_URL=.*|VITE_GLOB_API_URL=$VITE_GLOB_API_URL|" /app/apps/web-antd/.env.production
```

## 验证

- [ ] PR 合并后重新构建，`curl demo.nvuai.cc` 返回的 HTML 包含 `#__app-loading__`
- [ ] 打开演示站时显示品牌色加载动画，不再黑屏

Fixes #61