### PR TITLE
refactor(ci): release.sh 适配受保护分支，走 Release PR + 自动打标签

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,59 @@
+name: Auto Tag on Version Change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'VERSION'
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # 需要对比上一次 commit 的 VERSION
+
+      - name: Read version
+        id: ver
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if VERSION actually changed
+        id: changed
+        run: |
+          OLD_VERSION=$(git show HEAD~1:VERSION 2>/dev/null | tr -d '[:space:]' || echo "")
+          if [ "${{ steps.ver.outputs.version }}" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "VERSION 变更: $OLD_VERSION → ${{ steps.ver.outputs.version }}"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "VERSION 未变更，跳过打标签"
+          fi
+
+      - name: Check if tag already exists
+        if: steps.changed.outputs.changed == 'true'
+        id: exists
+        run: |
+          if git ls-remote --exit-code --tags origin "${{ steps.ver.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "标签 ${{ steps.ver.outputs.tag }} 已存在，跳过"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.changed.outputs.changed == 'true' && steps.exists.outputs.exists == 'false'
+        run: |
+          git tag -a "${{ steps.ver.outputs.tag }}" -m "Release ${{ steps.ver.outputs.tag }}"
+          git push origin "${{ steps.ver.outputs.tag }}"
+          echo "✓ 已创建并推送标签 ${{ steps.ver.outputs.tag }}"
+          echo "  → docker-images.yml 将自动构建镜像并发布 GitHub Release"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-# scripts/release.sh — 版本发布脚本
+# scripts/release.sh — 版本发布脚本（适配受保护分支）
 # 用法: ./scripts/release.sh [patch|minor|major|X.Y.Z]
 #
 # 功能:
 #   1. 读取 VERSION 文件中的当前版本号
 #   2. 按参数计算新版本号（patch/minor/major 或直接指定 X.Y.Z）
 #   3. 同步更新 VERSION 和 backend/pyproject.toml
-#   4. 提交变更并创建 vX.Y.Z 标签
-#   5. 推送到远端（推送标签自动触发 docker-images.yml 构建 + 发布）
+#   4. 创建 release/vX.Y.Z 分支并提交版本变更
+#   5. 通过 GitHub CLI 创建 Release PR
+#   6. PR 合并到 main 后，CI (auto-tag-release.yml) 自动打标签
+#      → 标签推送触发 docker-images.yml 构建镜像 + GitHub Release
 
 set -euo pipefail
 
@@ -66,8 +68,19 @@ if git rev-parse "$EXISTING_TAG" >/dev/null 2>&1; then
   exit 1
 fi
 
-# ── 更新版本号 ────────────────────────────────────────
+# ── 创建 Release 分支并提交 ─────────────────────────
+RELEASE_BRANCH="release/v${NEW_VERSION}"
+
+# 检查远端是否已存在同名分支
+if git ls-remote --exit-code --heads "$REMOTE" "$RELEASE_BRANCH" >/dev/null 2>&1; then
+  red "错误: 远端分支 $RELEASE_BRANCH 已存在，请先删除或手动处理"
+  exit 1
+fi
+
 cyan "当前版本: $CURRENT → 新版本: $NEW_VERSION"
+
+git switch -c "$RELEASE_BRANCH"
+cyan "✓ 已创建分支 $RELEASE_BRANCH"
 
 echo "$NEW_VERSION" > "$VERSION_FILE"
 cyan "✓ 已更新 VERSION"
@@ -82,28 +95,59 @@ else
 fi
 cyan "✓ 已更新 backend/pyproject.toml"
 
-# ── 提交 & 打标签 ─────────────────────────────────────
 git add "$VERSION_FILE" "$PYPROJECT"
 git commit -m "release: v${NEW_VERSION}"
-git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
 
-green "✓ 已提交并创建标签 v${NEW_VERSION}"
+green "✓ 已提交版本变更"
 
-# ── 推送 ─────────────────────────────────────────────
-printf '%s' "是否推送到远端 ${REMOTE}？[Y/n] "
+# ── 推送分支 & 创建 PR ──────────────────────────────
+printf '%s' "是否推送分支并创建 Release PR？[Y/n] "
 CONFIRM="Y"
 read -r CONFIRM || true
 CONFIRM="${CONFIRM:-Y}"
 
 if [[ "$CONFIRM" =~ ^[Yy] ]]; then
-  git push "$REMOTE" HEAD
-  git push "$REMOTE" "v${NEW_VERSION}"
-  green "✓ 已推送提交和标签到 $REMOTE"
+  git push -u "$REMOTE" "$RELEASE_BRANCH"
+  green "✓ 已推送分支 $RELEASE_BRANCH 到 $REMOTE"
+
+  # 通过 GitHub CLI 创建 Release PR
+  if command -v gh >/dev/null 2>&1; then
+    PR_URL=$(gh pr create \
+      --title "release: v${NEW_VERSION}" \
+      --body "## Release v${NEW_VERSION}
+
+版本变更：\`$CURRENT\` → \`$NEW_VERSION\`
+
+### 变更文件
+- \`VERSION\`
+- \`backend/pyproject.toml\`
+
+### 合并后自动流程
+1. \`auto-tag-release.yml\` 检测 VERSION 变更 → 创建标签 \`v${NEW_VERSION}\`
+2. \`docker-images.yml\` 被触发 → 构建 Docker 镜像 + 推送 GHCR
+3. 自动生成 GitHub Release（含 AI Release Notes）" \
+      --base main \
+      --head "$RELEASE_BRANCH" \
+      --label "release" 2>&1) || {
+      red "⚠ gh pr create 失败，请手动创建 PR:"
+      echo "  https://github.com/yzxingtu/novusai-saas/compare/main...$RELEASE_BRANCH"
+    }
+
+    if [[ "$PR_URL" == http* ]]; then
+      green "✓ 已创建 Release PR: $PR_URL"
+    fi
+  else
+    cyan "未安装 GitHub CLI，请手动创建 PR:"
+    echo "  https://github.com/yzxingtu/novusai-saas/compare/main...$RELEASE_BRANCH"
+  fi
+
   echo ""
-  green "GitHub Actions 将自动构建 Docker 镜像并发布 Release。"
+  green "后续流程（PR 合并后自动执行）："
+  green "  1. auto-tag-release.yml 检测 VERSION 变更 → 打标签 v${NEW_VERSION}"
+  green "  2. docker-images.yml 触发 → 构建镜像 + GitHub Release"
   green "查看进度: https://github.com/yzxingtu/novusai-saas/actions"
 else
-  cyan "跳过推送。稍后可手动执行:"
-  echo "  git push $REMOTE HEAD"
-  echo "  git push $REMOTE v${NEW_VERSION}"
+  cyan "跳过推送。分支已创建在本地，稍后可手动推送:"
+  echo "  git push -u $REMOTE $RELEASE_BRANCH"
+  echo "  gh pr create --base main --head $RELEASE_BRANCH --title 'release: v${NEW_VERSION}'"
 fi


### PR DESCRIPTION
## 背景

`main` 分支已启用保护规则，禁止直接推送。当前 `scripts/release.sh` 直接 `git push` 到 main 的方式已无法使用。

## 改动

### 1. 改造 `scripts/release.sh`

将直推逻辑改为 PR 流程：

| 步骤 | 旧流程 | 新流程 |
|------|--------|--------|
| 分支 | 在 main 上直接操作 | 创建 `release/vX.Y.Z` 分支 |
| 提交 | 提交版本变更 + 打标签 | 仅提交版本变更 |
| 推送 | `git push HEAD` + `git push tag` | `git push` 分支 + `gh pr create` |
| 打标签 | 本地手动 | CI 自动（合并后） |

新增检查：远端同名分支是否已存在，避免冲突。

### 2. 新增 `.github/workflows/auto-tag-release.yml`

监听 `push` 到 `main` 且 `VERSION` 文件变更的事件：

```
push to main (VERSION changed)
  → 读取新版本号
  → 对比上一个 commit 的 VERSION 确认实际变更
  → 检查标签是否已存在（防重复）
  → 创建并推送 vX.Y.Z 标签
  → docker-images.yml 自动触发
```

安全机制：
- `paths: ['VERSION']` — 只在 VERSION 文件变更时触发
- 对比 `HEAD~1:VERSION` 确认版本号确实不同
- `git ls-remote --tags` 检查标签是否已存在

### 3. 现有 `docker-images.yml` 无需任何改动

## 完整流程

```
./scripts/release.sh patch
  ↓
创建 release/v5.6.1 → 更新版本号 → push → 自动开 PR
  ↓
审查 + 合并 PR 到 main
  ↓
auto-tag-release.yml 检测 VERSION 变更 → 打标签 v5.6.1
  ↓
docker-images.yml 触发 → 构建 Docker 镜像 → 推送 GHCR → GitHub Release
```

Fixes #63