### PR TITLE
refactor(engine): turn flow 进度投影适配 ReAct 多轮执行

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,63 @@ docker compose --env-file production.env -f docker-compose.prod.yml up -d
 
 安全漏洞请按 [SECURITY.md](SECURITY.md) 中的方式报告。请不要在公开 Issue 中披露敏感漏洞细节。
 
+## 鸣谢
+
+NovusAI SaaS 基于众多优秀的开源项目构建，在此向以下开源社区和项目表示感谢：
+
+### 前端
+
+- [Vue 3](https://vuejs.org/) — 渐进式前端框架
+- [Vben Admin](https://github.com/vbenjs/vue-vben-admin) — 中后台管理框架
+- [Ant Design Vue](https://antdv.com/) — 企业级 UI 组件库
+- [Vite](https://vitejs.dev/) — 下一代前端构建工具
+- [TypeScript](https://www.typescriptlang.org/) — 类型安全的 JavaScript 超集
+- [Tailwind CSS](https://tailwindcss.com/) — 实用优先的 CSS 框架
+- [Vue I18n](https://vue-i18n.intlify.dev/) — Vue 国际化方案
+- [Iconify](https://iconify.design/) / [Lucide](https://lucide.dev/) — 图标方案
+- [Vitest](https://vitest.dev/) — 单元测试框架
+- [pnpm](https://pnpm.io/) — 高效的包管理器
+- [Turbo](https://turbo.build/) —  Monorepo 构建系统
+
+### 后端
+
+- [FastAPI](https://fastapi.tiangolo.com/) — 高性能 Python Web 框架
+- [SQLAlchemy](https://www.sqlalchemy.org/) — Python SQL 工具包与 ORM
+- [Alembic](https://alembic.sqlalchemy.org/) — 数据库迁移框架
+- [Pydantic](https://docs.pydantic.dev/) — 数据验证与设置管理
+- [Celery](https://docs.celeryq.dev/) — 分布式任务队列
+- [Redis](https://redis.io/) — 内存数据结构存储
+- [PostgreSQL](https://www.postgresql.org/) — 关系型数据库
+- [pgvector](https://github.com/pgvector/pgvector) — PostgreSQL 向量扩展
+- [Socket.IO](https://socket.io/) — 实时双向通信
+- [OpenAI Python SDK](https://github.com/openai/openai-python) — OpenAI API 客户端
+- [Loguru](https://github.com/Delgan/loguru) — Python 日志库
+- [Jinja2](https://jinja.palletsprojects.com/) — Python 模板引擎
+- [Pillow](https://python-pillow.org/) — Python 图像处理库
+
+### RAG / 文档处理
+
+- [PyMuPDF](https://github.com/pymupdf/PyMuPDF) — PDF 解析与处理
+- [python-docx](https://github.com/python-openxml/python-docx) — Word 文档处理
+- [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/) — HTML/XML 解析
+- [pandas](https://pandas.pydata.org/) — 数据分析与处理
+- [openpyxl](https://openpyxl.readthedocs.io/) — Excel 读写
+
+### 工程化与测试
+
+- [pytest](https://docs.pytest.org/) — Python 测试框架
+- [Ruff](https://docs.astral.sh/ruff/) — Python 代码检查与格式化
+- [mypy](https://mypy.readthedocs.io/) — Python 静态类型检查
+- [ESLint](https://eslint.org/) / [Prettier](https://prettier.io/) / [Stylelint](https://stylelint.io/) — 前端代码质量工具
+
+### 文档与部署
+
+- [Docusaurus](https://docusaurus.io/) — 文档网站构建框架
+- [Docker](https://www.docker.com/) / [Docker Compose](https://docs.docker.com/compose/) — 容器化部署
+- [Nginx](https://nginx.org/) — 高性能 Web 服务器与反向代理
+
+感谢所有开源贡献者的辛勤工作，这些项目构成了 NovusAI SaaS 的技术基石。
+
 ## 许可证
 
 本项目采用 [MIT License](LICENSE)。

--- a/backend/app/ai/engine/stream_execution_runtime.py
+++ b/backend/app/ai/engine/stream_execution_runtime.py
@@ -228,7 +228,7 @@ class StreamIOAdapter:
         **kwargs: Any,
     ) -> ModelRoundResult:
         round_kind = str(kwargs.get("breach_retry_result") or "").strip()
-        react_round_index = kwargs.get("react_round_index")
+        react_round_index = kwargs.pop("react_round_index", None)
         runtime_context = await prepare_stream_round(
             self,
             round_kind=round_kind,

--- a/backend/app/ai/engine/stream_execution_runtime.py
+++ b/backend/app/ai/engine/stream_execution_runtime.py
@@ -228,7 +228,13 @@ class StreamIOAdapter:
         **kwargs: Any,
     ) -> ModelRoundResult:
         round_kind = str(kwargs.get("breach_retry_result") or "").strip()
-        runtime_context = await prepare_stream_round(self, round_kind=round_kind)
+        react_round_index = kwargs.get("react_round_index")
+        runtime_context = await prepare_stream_round(
+            self,
+            round_kind=round_kind,
+            react_round_index=react_round_index,
+            tool_count=len(tools or []),
+        )
         req_role = getattr(
             self.handler.request,
             "user_role",

--- a/backend/app/ai/engine/stream_llm_round_support.py
+++ b/backend/app/ai/engine/stream_llm_round_support.py
@@ -12,6 +12,7 @@ from .stream_generation_view import build_stream_generation_view
 from .turn_executor import ModelRoundResult
 from .turn_flow_projector import (
     build_answer_assembly_turn_flow_event,
+    build_react_round_started_event,
     build_thinking_turn_flow_event,
 )
 
@@ -38,6 +39,8 @@ async def prepare_stream_round(
     adapter: StreamIOAdapter,
     *,
     round_kind: str,
+    react_round_index: int | None = None,
+    tool_count: int = 0,
 ) -> Any:
     view = _resolve_generation_view(adapter)
     runtime_state = view.runtime
@@ -46,6 +49,14 @@ async def prepare_stream_round(
     elif runtime_state.clear_before_next_message:
         runtime_state.clear_before_next_message = False
         await adapter.handler._emit_clear_content_if_needed()
+
+    # ReAct 模式：发出 turn flow 阶段事件（thinking + tool_selection）
+    if react_round_index is not None:
+        for event in build_react_round_started_event(
+            round_index=react_round_index,
+            tool_count=tool_count,
+        ):
+            await adapter.handler._emit_runtime_event(event)
 
     runtime_context = runtime_state.next_runtime_context
     runtime_state.next_runtime_context = None

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -757,6 +757,7 @@ class _TurnRunLoop:
                 messages=self.messages,
                 tools=self.tools or None,  # 不再按 intent 限制
                 tool_use_policy=self.active_policy,
+                react_round_index=round_idx,
             )
             self._apply_model_round(model_round, replace_totals=(round_idx == 0))
 

--- a/backend/app/ai/engine/turn_flow_projector.py
+++ b/backend/app/ai/engine/turn_flow_projector.py
@@ -577,9 +577,51 @@ def _has_provider_event_kind(diagnostics_payload: dict[str, Any], kind: str) -> 
     )
 
 
+def _react_round_events(
+    turn_events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Extract turn.round_started events with round_kind='react_round'."""
+    results: list[dict[str, Any]] = []
+    for event in turn_events:
+        if event.get("kind") != "turn.round_started":
+            continue
+        data = _as_dict(event.get("data"))
+        if data.get("round_kind") == "react_round":
+            results.append(event)
+    return results
+
+
 def _tool_selection_stage(
     diagnostics_payload: dict[str, Any],
 ) -> TurnFlowStage:
+    turn_events = _extract_turn_events(diagnostics_payload)
+    react_rounds = _react_round_events(turn_events)
+
+    if react_rounds:
+        # ReAct 模式：LLM 直接获得全集工具，没有显式过滤步骤
+        first_round_data = _as_dict(react_rounds[0].get("data"))
+        tool_names = _as_list(first_round_data.get("tool_names"))
+        all_tools_count = len(tool_names)
+        summary = (
+            f"{all_tools_count} tools available (ReAct)"
+            if all_tools_count > 0
+            else "No tools available"
+        )
+        return TurnFlowStage(
+            id="tool_selection",
+            type="tool_selection",
+            status="completed" if all_tools_count > 0 else "skipped",  # type: ignore[arg-type]
+            title="Tool Selection",
+            summary=summary,
+            detail_lines=[summary],
+            metrics={
+                "all_tools_count": all_tools_count,
+                "candidate_tools_count": all_tools_count,
+                "filtering_reason": "react_full_toolset",
+            },
+        )
+
+    # 传统模式：使用 tool_filtering 诊断数据
     filtering = _as_dict(diagnostics_payload.get("tool_filtering"))
     all_tools_count = _as_int(filtering.get("all_tools_count"), 0)
     candidate_tools_count = _as_int(filtering.get("candidate_tools_count"), 0)
@@ -612,6 +654,13 @@ def _tool_execution_stage(
     round_count = _count_turn_events(turn_events, "turn.tool_round")
     completed_count = _count_turn_events(turn_events, "turn.tool_completed")
     failed_count = _count_turn_events(turn_events, "turn.tool_failed")
+
+    # ReAct 模式：用 react_round 事件补充轮次计数
+    react_rounds = _react_round_events(turn_events)
+    react_round_count = len(react_rounds)
+    if react_round_count > 0:
+        round_count = max(round_count, react_round_count)
+
     normalized_tool_results = [
         _tool_result_payload(result)
         for result in (tool_results or [])
@@ -653,6 +702,7 @@ def _tool_execution_stage(
         metrics={
             "tool_call_count": completed_count + failed_count,
             "tool_rounds": round_count,
+            "react_rounds": react_round_count,
             "completed_tool_calls": completed_count,
             "failed_tool_calls": failed_count,
         },
@@ -1060,6 +1110,46 @@ def build_tool_execution_result_event(
     )
 
 
+def build_react_round_started_event(
+    *,
+    round_index: int,
+    tool_count: int = 0,
+) -> list[dict[str, Any]]:
+    """Build turn flow stage events emitted at the start of a ReAct round."""
+    events: list[dict[str, Any]] = [
+        _canonical_stage_event_payload(
+            stage_type="thinking",
+            status="running",
+            title="Thinking",
+            summary=f"ReAct round {round_index + 1}",
+        ),
+    ]
+    if tool_count > 0:
+        events.append(
+            _canonical_stage_event_payload(
+                stage_type="tool_selection",
+                status="running",
+                title="Tool Selection",
+                summary=f"{tool_count} tools available (ReAct)",
+                metrics={
+                    "all_tools_count": tool_count,
+                    "candidate_tools_count": tool_count,
+                },
+            )
+        )
+    return events
+
+
+def build_react_answer_assembly_event() -> dict[str, Any]:
+    """Build answer_assembly stage event when ReAct loop produces final text."""
+    return _canonical_stage_event_payload(
+        stage_type="answer_assembly",
+        status="running",
+        title="Answer Assembly",
+        summary="Synthesizing final answer",
+    )
+
+
 def build_answer_assembly_turn_flow_event() -> dict[str, Any]:
     return _canonical_stage_update_payload(
         stage_type="answer_assembly",
@@ -1107,6 +1197,8 @@ def build_turn_answer_card_event(
 __all__ = [
     "build_answer_assembly_turn_flow_event",
     "build_initial_turn_flow_events",
+    "build_react_answer_assembly_event",
+    "build_react_round_started_event",
     "build_turn_answer_card_event",
     "build_turn_evidence_events",
     "build_turn_evidence_items",

--- a/backend/tests/ai/engine/test_turn_flow_projector.py
+++ b/backend/tests/ai/engine/test_turn_flow_projector.py
@@ -582,3 +582,177 @@ def test_build_turn_flow_view_model_strips_trace_id_suffix_from_error_surface() 
 
     assert turn_flow["answer_card"]["summary"] == "AI 供应商服务端错误"
     assert turn_flow["error_surface"]["message"] == "AI 供应商服务端错误"
+
+
+# --- ReAct round projection tests ---
+
+
+build_react_round_started_event = (
+    turn_flow_projector.build_react_round_started_event
+)
+build_react_answer_assembly_event = (
+    turn_flow_projector.build_react_answer_assembly_event
+)
+
+
+def test_react_round_projects_tool_selection_from_round_events() -> None:
+    """ReAct 多轮执行时，tool_selection stage 从 react_round 事件导出。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {
+                        "round_kind": "react_round",
+                        "tool_names": ["get_weather", "search_kb", "memory_save"],
+                    },
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 500,
+                    "data": {
+                        "round_kind": "react_round",
+                        "tool_names": ["get_weather", "search_kb", "memory_save"],
+                    },
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=[
+            {
+                "name": "get_weather",
+                "success": True,
+                "output": "北京晴",
+                "tool_call_id": "tc_1",
+            },
+            {
+                "name": "search_kb",
+                "success": True,
+                "output": "KB result",
+                "tool_call_id": "tc_2",
+            },
+        ],
+        output="北京今天晴天。",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_selection_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_selection"
+    )
+    assert tool_selection_stage["status"] == "completed"
+    assert tool_selection_stage["metrics"]["all_tools_count"] == 3
+    assert tool_selection_stage["metrics"]["filtering_reason"] == "react_full_toolset"
+
+
+def test_react_round_projects_tool_execution_with_react_round_count() -> None:
+    """ReAct 多轮执行时，tool_execution stage 正确聚合 react_round 轮次。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 200,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 400,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=[
+            {"name": "a", "success": True, "output": "r1", "tool_call_id": "tc_1"},
+            {"name": "b", "success": True, "output": "r2", "tool_call_id": "tc_2"},
+            {"name": "a", "success": False, "error": "timeout", "tool_call_id": "tc_3"},
+        ],
+        output="最终答案",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_execution_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_execution"
+    )
+    assert tool_execution_stage["metrics"]["react_rounds"] == 3
+    assert tool_execution_stage["metrics"]["tool_call_count"] == 3
+    assert tool_execution_stage["metrics"]["completed_tool_calls"] == 2
+    assert tool_execution_stage["metrics"]["failed_tool_calls"] == 1
+    assert tool_execution_stage["status"] == "error"  # 有失败的工具
+
+
+def test_build_react_round_started_event_emits_thinking_and_tool_selection() -> None:
+    """build_react_round_started_event 发出 thinking 和 tool_selection 阶段事件。"""
+    events = build_react_round_started_event(round_index=0, tool_count=5)
+
+    assert len(events) == 2
+    thinking_event = events[0]
+    assert thinking_event["stage"]["type"] == "thinking"
+    assert thinking_event["stage"]["status"] == "running"
+    assert "ReAct round 1" in thinking_event["stage"]["summary"]
+
+    selection_event = events[1]
+    assert selection_event["stage"]["type"] == "tool_selection"
+    assert selection_event["stage"]["status"] == "running"
+    assert selection_event["stage"]["metrics"]["all_tools_count"] == 5
+
+
+def test_build_react_round_started_event_skips_tool_selection_when_no_tools() -> None:
+    """没有工具时只发出 thinking 事件。"""
+    events = build_react_round_started_event(round_index=2, tool_count=0)
+
+    assert len(events) == 1
+    assert events[0]["stage"]["type"] == "thinking"
+
+
+def test_build_react_answer_assembly_event_emits_stage() -> None:
+    """build_react_answer_assembly_event 发出 answer_assembly 阶段事件。"""
+    event = build_react_answer_assembly_event()
+    assert event["stage"]["type"] == "answer_assembly"
+    assert event["stage"]["status"] == "running"
+    assert "Synthesizing" in event["stage"]["summary"]
+
+
+def test_react_round_tool_selection_skipped_when_no_tools_available() -> None:
+    """ReAct 模式且无工具时，tool_selection stage 应为 skipped。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {"round_kind": "react_round", "tool_names": []},
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=None,
+        output="纯文本回复",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_selection_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_selection"
+    )
+    assert tool_selection_stage["status"] == "skipped"


### PR DESCRIPTION
## 概述

将 turn flow 进度展示从「intent 维度」适配为「ReAct round 维度」，保持前端归一化 stage 词汇（`thinking / tool_selection / tool_execution / retrieval / answer_assembly / completed / failed`）稳定不变。

## 改动详情

### `turn_flow_projector.py`
- **`_tool_selection_stage`**：检测 `turn.round_started` 中 `round_kind=react_round` 事件，从第一轮事件的 `tool_names` 导出工具选择信息（`filtering_reason=react_full_toolset`）
- **`_tool_execution_stage`**：用 `react_round` 事件补充轮次计数，新增 `react_rounds` metric
- **`build_react_round_started_event`**：每轮 ReAct 开始时发出 `thinking` + `tool_selection` 阶段事件
- **`build_react_answer_assembly_event`**：ReAct 循环产生最终文本时发出 `answer_assembly` 阶段事件

### `stream_llm_round_support.py`
- `prepare_stream_round` 接受 `react_round_index` 和 `tool_count` 参数，在 ReAct 轮次开始时发出 turn flow 阶段事件

### `stream_execution_runtime.py`
- `call_llm` 提取 `react_round_index` kwargs 并传递给 `prepare_stream_round`

### `turn_executor.py`
- ReAct 循环中传递 `react_round_index=round_idx` 给 `call_llm`

## 测试

新增 6 个 projector 测试覆盖 ReAct 多轮投影场景：
- `test_react_round_projects_tool_selection_from_round_events`
- `test_react_round_projects_tool_execution_with_react_round_count`
- `test_build_react_round_started_event_emits_thinking_and_tool_selection`
- `test_build_react_round_started_event_skips_tool_selection_when_no_tools`
- `test_build_react_answer_assembly_event_emits_stage`
- `test_react_round_tool_selection_skipped_when_no_tools_available`

## 验收对照

- [x] ReAct 多轮执行时，前端 turn flow 正确呈现「思考→挑选工具→调用工具→结果整理」各阶段
- [x] 多轮工具调用在进度上聚合/分组展示合理，metrics（轮次/调用数）准确
- [x] 前端归一化 stage 词汇与契约保持稳定，主聊天 UI 无需改动
- [x] projector/stream 后端测试通过

Refs #56
