### PR TITLE
refactor(engine): ReAct 多轮自主执行循环集成 + 多轮/授权缺陷修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,63 @@ docker compose --env-file production.env -f docker-compose.prod.yml up -d
 
 安全漏洞请按 [SECURITY.md](SECURITY.md) 中的方式报告。请不要在公开 Issue 中披露敏感漏洞细节。
 
+## 鸣谢
+
+NovusAI SaaS 基于众多优秀的开源项目构建，在此向以下开源社区和项目表示感谢：
+
+### 前端
+
+- [Vue 3](https://vuejs.org/) — 渐进式前端框架
+- [Vben Admin](https://github.com/vbenjs/vue-vben-admin) — 中后台管理框架
+- [Ant Design Vue](https://antdv.com/) — 企业级 UI 组件库
+- [Vite](https://vitejs.dev/) — 下一代前端构建工具
+- [TypeScript](https://www.typescriptlang.org/) — 类型安全的 JavaScript 超集
+- [Tailwind CSS](https://tailwindcss.com/) — 实用优先的 CSS 框架
+- [Vue I18n](https://vue-i18n.intlify.dev/) — Vue 国际化方案
+- [Iconify](https://iconify.design/) / [Lucide](https://lucide.dev/) — 图标方案
+- [Vitest](https://vitest.dev/) — 单元测试框架
+- [pnpm](https://pnpm.io/) — 高效的包管理器
+- [Turbo](https://turbo.build/) —  Monorepo 构建系统
+
+### 后端
+
+- [FastAPI](https://fastapi.tiangolo.com/) — 高性能 Python Web 框架
+- [SQLAlchemy](https://www.sqlalchemy.org/) — Python SQL 工具包与 ORM
+- [Alembic](https://alembic.sqlalchemy.org/) — 数据库迁移框架
+- [Pydantic](https://docs.pydantic.dev/) — 数据验证与设置管理
+- [Celery](https://docs.celeryq.dev/) — 分布式任务队列
+- [Redis](https://redis.io/) — 内存数据结构存储
+- [PostgreSQL](https://www.postgresql.org/) — 关系型数据库
+- [pgvector](https://github.com/pgvector/pgvector) — PostgreSQL 向量扩展
+- [Socket.IO](https://socket.io/) — 实时双向通信
+- [OpenAI Python SDK](https://github.com/openai/openai-python) — OpenAI API 客户端
+- [Loguru](https://github.com/Delgan/loguru) — Python 日志库
+- [Jinja2](https://jinja.palletsprojects.com/) — Python 模板引擎
+- [Pillow](https://python-pillow.org/) — Python 图像处理库
+
+### RAG / 文档处理
+
+- [PyMuPDF](https://github.com/pymupdf/PyMuPDF) — PDF 解析与处理
+- [python-docx](https://github.com/python-openxml/python-docx) — Word 文档处理
+- [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/) — HTML/XML 解析
+- [pandas](https://pandas.pydata.org/) — 数据分析与处理
+- [openpyxl](https://openpyxl.readthedocs.io/) — Excel 读写
+
+### 工程化与测试
+
+- [pytest](https://docs.pytest.org/) — Python 测试框架
+- [Ruff](https://docs.astral.sh/ruff/) — Python 代码检查与格式化
+- [mypy](https://mypy.readthedocs.io/) — Python 静态类型检查
+- [ESLint](https://eslint.org/) / [Prettier](https://prettier.io/) / [Stylelint](https://stylelint.io/) — 前端代码质量工具
+
+### 文档与部署
+
+- [Docusaurus](https://docusaurus.io/) — 文档网站构建框架
+- [Docker](https://www.docker.com/) / [Docker Compose](https://docs.docker.com/compose/) — 容器化部署
+- [Nginx](https://nginx.org/) — 高性能 Web 服务器与反向代理
+
+感谢所有开源贡献者的辛勤工作，这些项目构成了 NovusAI SaaS 的技术基石。
+
 ## 许可证
 
 本项目采用 [MIT License](LICENSE)。

--- a/backend/app/ai/engine/budget_guard.py
+++ b/backend/app/ai/engine/budget_guard.py
@@ -12,7 +12,7 @@ class BudgetGuard:
             return ExecutionBudget(
                 max_prompt_tokens=4000,
                 max_completion_tokens=2000,
-                max_tool_rounds=2,
+                max_tool_rounds=4,
                 max_elapsed_ms=40000,
                 max_retry_per_intent=1,
                 max_candidate_tools=3,
@@ -23,7 +23,7 @@ class BudgetGuard:
             return ExecutionBudget(
                 max_prompt_tokens=8000,
                 max_completion_tokens=4000,
-                max_tool_rounds=3,
+                max_tool_rounds=8,
                 max_elapsed_ms=60000,
                 max_retry_per_intent=1,
                 max_candidate_tools=7,
@@ -33,7 +33,7 @@ class BudgetGuard:
         return ExecutionBudget(
             max_prompt_tokens=12000,
             max_completion_tokens=6000,
-            max_tool_rounds=min(6, max(2, intent_count * 2)),
+            max_tool_rounds=min(12, max(4, intent_count * 3)),
             max_elapsed_ms=75000,
             max_retry_per_intent=1,
             max_candidate_tools=8,

--- a/backend/app/ai/engine/stream_execution_runtime.py
+++ b/backend/app/ai/engine/stream_execution_runtime.py
@@ -228,7 +228,7 @@ class StreamIOAdapter:
         **kwargs: Any,
     ) -> ModelRoundResult:
         round_kind = str(kwargs.get("breach_retry_result") or "").strip()
-        react_round_index = kwargs.get("react_round_index")
+        react_round_index = kwargs.pop("react_round_index", None)
         runtime_context = await prepare_stream_round(
             self,
             round_kind=round_kind,

--- a/backend/app/ai/engine/stream_execution_runtime.py
+++ b/backend/app/ai/engine/stream_execution_runtime.py
@@ -228,7 +228,13 @@ class StreamIOAdapter:
         **kwargs: Any,
     ) -> ModelRoundResult:
         round_kind = str(kwargs.get("breach_retry_result") or "").strip()
-        runtime_context = await prepare_stream_round(self, round_kind=round_kind)
+        react_round_index = kwargs.get("react_round_index")
+        runtime_context = await prepare_stream_round(
+            self,
+            round_kind=round_kind,
+            react_round_index=react_round_index,
+            tool_count=len(tools or []),
+        )
         req_role = getattr(
             self.handler.request,
             "user_role",

--- a/backend/app/ai/engine/stream_llm_round_support.py
+++ b/backend/app/ai/engine/stream_llm_round_support.py
@@ -12,6 +12,7 @@ from .stream_generation_view import build_stream_generation_view
 from .turn_executor import ModelRoundResult
 from .turn_flow_projector import (
     build_answer_assembly_turn_flow_event,
+    build_react_round_started_event,
     build_thinking_turn_flow_event,
 )
 
@@ -38,6 +39,8 @@ async def prepare_stream_round(
     adapter: StreamIOAdapter,
     *,
     round_kind: str,
+    react_round_index: int | None = None,
+    tool_count: int = 0,
 ) -> Any:
     view = _resolve_generation_view(adapter)
     runtime_state = view.runtime
@@ -46,6 +49,14 @@ async def prepare_stream_round(
     elif runtime_state.clear_before_next_message:
         runtime_state.clear_before_next_message = False
         await adapter.handler._emit_clear_content_if_needed()
+
+    # ReAct 模式：发出 turn flow 阶段事件（thinking + tool_selection）
+    if react_round_index is not None:
+        for event in build_react_round_started_event(
+            round_index=react_round_index,
+            tool_count=tool_count,
+        ):
+            await adapter.handler._emit_runtime_event(event)
 
     runtime_context = runtime_state.next_runtime_context
     runtime_state.next_runtime_context = None

--- a/backend/app/ai/engine/tool_round_execution_helpers.py
+++ b/backend/app/ai/engine/tool_round_execution_helpers.py
@@ -33,6 +33,22 @@ class ToolRoundExecutionOutcome:
     early_return: tuple[ChatResponse | None, list[ToolResult], int, int] | None = None
 
 
+def _trim_last_assistant_tool_calls(
+    messages: list[ChatMessage],
+    kept_tool_calls: list[dict[str, Any]],
+) -> None:
+    """将最近一条带 tool_calls 的 assistant 消息收敛为 kept_tool_calls。
+
+    consent 门控暂停时，已追加的 assistant 消息可能包含当前待确认工具之后
+    尚未执行的 tool_calls，这些 tool_calls 没有匹配的 tool 响应，会在历史
+    重投时触发 provider 报错。此处将其裁剪为已处理 + 当前待确认的部分。
+    """
+    for message in reversed(messages):
+        if message.role == "assistant" and message.tool_calls:
+            message.tool_calls = list(kept_tool_calls)
+            return
+
+
 def prepare_parallel_readonly_batch(
     *,
     processor: ToolCallProcessor,
@@ -214,7 +230,7 @@ async def execute_tool_round(
             tracked_tool_result_bytes=state.tracked_tool_result_bytes
         )
 
-    for tc in tool_calls:
+    for tc_index, tc in enumerate(tool_calls):
         tc_id = tc.get("id", "")
         func = tc.get("function", {})
         func_name = func.get("name", "")
@@ -245,6 +261,12 @@ async def execute_tool_round(
                         arguments,
                     )
                 )
+                # Consent 门控暂停时，丢弃当前待确认工具之后尚未执行的 tool_calls，
+                # 仅保留「已处理 + 当前待确认」这一段。被保留项均有匹配的 tool 消息
+                # （执行结果 / 拒绝消息 / consent_ask 消息），避免历史重投时出现无
+                # 匹配 tool 响应的孤儿 tool_calls。
+                kept_tool_calls = list(tool_calls[: tc_index + 1])
+                _trim_last_assistant_tool_calls(state.messages, kept_tool_calls)
                 return ToolRoundExecutionOutcome(
                     tracked_tool_result_bytes=state.tracked_tool_result_bytes,
                     early_return=(
@@ -252,7 +274,7 @@ async def execute_tool_round(
                             message=ChatMessage(
                                 role="assistant",
                                 content=current_response.message.content or "",
-                                tool_calls=tool_calls,
+                                tool_calls=kept_tool_calls,
                                 metadata={"pending_consent": pending_consent},
                             ),
                             metadata={

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -833,8 +833,12 @@ class _TurnRunLoop:
 
         当工具执行需要用户确认时（consent_mode="ask"），
         构建 pause_for_consent decision 并暂停执行。
-        复用 RecoveryManager.decide 获取 decision。
+        
+        检查两层：
+        1. 先从 intent_plan 检查（传统流程）
+        2. 再从 messages 直接检查（ReAct 动态工具选择流程）
         """
+        # 传统检查：基于 intent_plan
         decision = RecoveryManager.decide(
             self.state.intent_plan,
             budget=self.state.budget,
@@ -843,6 +847,31 @@ class _TurnRunLoop:
         if decision is not None and decision.action == "pause_for_consent":
             self.decision = decision
             return True
+        
+        # ReAct 补充检查：直接从 messages 检查 pending_consent
+        # ReAct 流程中 intent_plan 可能未包含动态选择的工具，
+        # 需要从 messages 直接提取 pending_consent payload
+        from .recovery_consent_helpers import extract_pending_consent_payload
+        pending_payload = extract_pending_consent_payload(self.messages)
+        if pending_payload and not pending_payload.get("resolved"):
+            self.decision = RecoveryDecision(
+                action="pause_for_consent",
+                target_intent_id=None,
+                completed_intent_ids=[
+                    item.intent_id
+                    for item in self.state.intent_plan
+                    if item.status == "completed"
+                ],
+                unfinished_intent_ids=[
+                    item.intent_id
+                    for item in self.state.intent_plan
+                    if item.status not in {"completed", "skipped"}
+                ],
+                reason="awaiting_user_consent",
+                metadata={"pending_consent": pending_payload},
+            )
+            return True
+        
         return False
 
     async def _run_shortcircuit_summary(self) -> None:

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -670,6 +670,7 @@ class _TurnRunLoop:
                 if sc_kind == "confirmation_replay":
                     # confirmation_replay 执行完写操作后，进入完整 ReAct 循环
                     # 让 LLM 用全集工具继续后续步骤（如创建后发布）
+                    self._restore_full_tools_for_react()
                     await self._run_react_loop()
                 # time_query 等短路工具结果即最终回复，无需额外处理
             return await self._finalize_result()
@@ -703,6 +704,27 @@ class _TurnRunLoop:
             return True
 
         return False
+
+    def _restore_full_tools_for_react(self) -> None:
+        """confirmation_replay 短路后恢复全集工具和 auto 策略。
+
+        短路阶段只加载了 replay 工具（invoke_internal_operation），
+        进入 ReAct 循环前需要恢复完整工具集（含 list/describe/invoke），
+        否则 LLM 无法发现和调用后续操作（如发布）。
+        """
+        full_tools = getattr(self.prep, "all_tools", None) or []
+        if full_tools:
+            self.tools = list(full_tools)
+            self.active_tools = self.tools
+        # 重置 policy 为 auto 模式，允许 LLM 自主选择工具
+        all_tool_names = [t.name for t in self.tools]
+        self.active_policy = ToolUsePolicy(
+            family=self.active_policy.family if self.active_policy else "internal_ops",
+            mode="auto",
+            allowed_tool_names=all_tool_names,
+            retry_on_contract_breach=True,
+            reason="confirmation_replay_post_react_full_tools",
+        )
 
     def _max_tool_rounds(self) -> int:
         """获取最大工具轮次数。"""

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -503,15 +503,12 @@ class _TurnRunLoop:
         self.messages = self.prep.messages
         self.turn_start_index = current_turn_start_index(self.messages)
         self.tools = list(self.prep.tools or [])
+        # ReAct: 使用全集工具，不再按 intent 限制工具选择
+        # Intent 暂时保留用于确定性短路和诊断（待 #50-C 清理）
+        self.active_tools = self.tools
         self.active_policy = self.prep.tool_use_policy
-        self.active_tools, self.active_policy, self.intent = (
-            TurnExecutor._scope_tools_to_active_intent(
-                state=self.state,
-                tools=self.tools,
-                policy=self.active_policy,
-                io=self.io,
-            )
-        )
+        # 保留 intent 用于确定性短路检查，但不用于工具选择
+        self.intent = active_intent(self.state)
 
     @property
     def turn_messages(self) -> list[ChatMessage]:
@@ -658,12 +655,173 @@ class _TurnRunLoop:
         intent.metadata["clarification_requested"] = True
 
     async def run(self) -> TurnExecutionResult:
-        await self._run_initial_round()
-        await self._run_tool_batch_or_update_intents()
-        await self._run_contract_retry_round()
-        await self._run_intent_retry_loop()
-        await self._maybe_run_post_tool_follow_up_round()
+        # Phase 1: 短路检查（保留确定性短路）
+        shortcircuit_applied = await self._try_shortcircuit()
+
+        # Phase 2: ReAct 循环（如果是短路且有 tool_calls，则执行工具后结束）
+        if shortcircuit_applied:
+            # 确定性短路设置了 synthetic response，需要执行工具
+            if getattr(self.response, "tool_calls", None):
+                await self._execute_tool_batch_in_loop()
+            return await self._finalize_result()
+
+        await self._run_react_loop()
+
+        # Phase 3: 结果整理
         return await self._finalize_result()
+
+    async def _try_shortcircuit(self) -> bool:
+        """尝试确定性短路，返回 True 表示已短路。
+
+        保留的短路类型：
+        - cached_shortcircuit: 缓存结果直接返回
+        - deterministic_tool_shortcircuit: time_query / confirmation_replay / memory_*
+        - missing_args_clarification: 缺失参数澄清
+        """
+        # 1. 缓存短路
+        shortcircuit_intent = cached_shortcircuit_intent(self.state)
+        if shortcircuit_intent is not None:
+            self._apply_cached_shortcircuit(shortcircuit_intent)
+            return True
+
+        # 2. 确定性工具短路（time_query/confirmation_replay/memory_save/memory_recall）
+        if self._apply_deterministic_tool_shortcircuit():
+            return True
+
+        # 3. 缺失参数澄清（暂时保留，待 #50-C 清理）
+        if intent_requires_clarification(self.intent):
+            await self._run_missing_args_clarification(self.intent)
+            return True
+
+        return False
+
+    def _max_tool_rounds(self) -> int:
+        """获取最大工具轮次数。"""
+        if self.state.budget is None or self.state.budget.max_tool_rounds <= 0:
+            return 8  # 默认值
+        return int(self.state.budget.max_tool_rounds)
+
+    def _handle_budget_exit(self, reason: str) -> None:
+        """处理预算耗尽情况。"""
+        self.state.register_provider_failure(
+            kind="budget_exit",
+            event={"kind": "budget_exit", "reason": reason},
+        )
+        # 构建空响应
+        self.response = ChatResponse(
+            message=ChatMessage(role="assistant", content=""),
+            total_tokens=0,
+            output_tokens=0,
+        )
+        # 设置 decision 为 partial exit
+        self.decision = RecoveryDecision(
+            action="return_partial",
+            reason=reason,
+            provider_failure_kind="budget_exit",
+        )
+
+    async def _run_react_loop(self) -> None:
+        """LLM 带全集工具循环调用，直到纯文本回复或预算耗尽。
+
+        ReAct 循环流程：
+        1. 检查预算
+        2. 调用 LLM（带全集工具）
+        3. 如果有 tool_calls：执行工具 → 结果回写 → 继续循环
+        4. 如果无 tool_calls：检查 consent gate → 纯文本回复，循环结束
+        """
+        max_rounds = self._max_tool_rounds()
+
+        # 初始预算检查
+        initial_budget_exit = self.state.budget_exit_reason()
+        if initial_budget_exit:
+            self._handle_budget_exit(initial_budget_exit)
+            return
+
+        for round_idx in range(max_rounds):
+            # 预算检查
+            budget_exit = self.state.budget_exit_reason()
+            if budget_exit:
+                self._handle_budget_exit(budget_exit)
+                return
+
+            # 发出 round 事件
+            self.emit_round(
+                round_kind="react_round",
+                policy=self.active_policy,
+                tools=self.tools,  # 全集工具
+                reason=f"react_round_{round_idx}",
+            )
+
+            # LLM 调用（带全集工具）
+            model_round = await self.io.call_llm(
+                messages=self.messages,
+                tools=self.tools or None,  # 不再按 intent 限制
+                tool_use_policy=self.active_policy,
+            )
+            self._apply_model_round(model_round, replace_totals=(round_idx == 0))
+
+            # 无 tool_calls → 检查 consent gate 然后结束
+            if not getattr(self.response, "tool_calls", None):
+                # 在纯文本回复后检查 consent gate（可能从恢复场景来）
+                await self._check_consent_gate()
+                return
+
+            # 确认门控检查（工具执行前检查）
+            if await self._check_consent_gate():
+                return  # 暂停等待用户确认
+
+            # 执行工具批次
+            await self._execute_tool_batch_in_loop()
+
+            # 工具执行后再次检查确认门控
+            if await self._check_consent_gate():
+                return
+
+            # 注册工具轮次
+            self.state.register_tool_round()
+
+        # 循环结束但仍有 tool_calls，说明预算耗尽
+        budget_exit = self.state.budget_exit_reason() or "tool_round_budget_exceeded"
+        self._handle_budget_exit(budget_exit)
+
+    async def _execute_tool_batch_in_loop(self) -> None:
+        """在 ReAct 循环内执行工具批次。"""
+        (
+            self.response,
+            extra_tool_results,
+            self.total_tokens,
+            self.completion_tokens_used,
+        ) = await execute_tool_batch(
+            state=self.state,
+            io=self.io,
+            response=self.response,
+            tools=self.tools,  # 全集
+            all_tools=self.prep.all_tools or self.tools,
+            messages=self.messages,
+            turn_messages=self.turn_messages,
+            tool_use_policy=self.active_policy,
+            input_variables=self.request.input_variables,
+            total_tokens=self.total_tokens,
+            completion_tokens_used=self.completion_tokens_used,
+        )
+        self.tool_results.extend(extra_tool_results)
+
+    async def _check_consent_gate(self) -> bool:
+        """检查是否需要用户确认，返回 True 表示已暂停。
+
+        当工具执行需要用户确认时（consent_mode="ask"），
+        构建 pause_for_consent decision 并暂停执行。
+        复用 RecoveryManager.decide 获取 decision。
+        """
+        decision = RecoveryManager.decide(
+            self.state.intent_plan,
+            budget=self.state.budget,
+            provider_failure_kind=self.state.provider_failure_kind,
+        )
+        if decision is not None and decision.action == "pause_for_consent":
+            self.decision = decision
+            return True
+        return False
 
     async def _run_initial_round(self) -> None:
         initial_budget_exit = self.state.budget_exit_reason()

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -698,7 +698,7 @@ class _TurnRunLoop:
     def _max_tool_rounds(self) -> int:
         """获取最大工具轮次数。"""
         if self.state.budget is None or self.state.budget.max_tool_rounds <= 0:
-            return 8  # 默认值
+            return 6  # 默认值（TODO: 后续从智能体配置读取）
         return int(self.state.budget.max_tool_rounds)
 
     def _handle_budget_exit(self, reason: str) -> None:
@@ -752,11 +752,24 @@ class _TurnRunLoop:
                 reason=f"react_round_{round_idx}",
             )
 
+            # ReAct 第 2 轮起 tool_choice 改为 auto，允许 LLM 给出纯文本回复退出循环
+            round_policy = (
+                self.active_policy
+                if round_idx == 0
+                else ToolUsePolicy(
+                    family=self.active_policy.family,
+                    mode="auto",
+                    allowed_tool_names=self.active_policy.allowed_tool_names,
+                    retry_on_contract_breach=self.active_policy.retry_on_contract_breach,
+                    reason=f"{self.active_policy.reason}:react_round_{round_idx}_auto",
+                )
+            )
+
             # LLM 调用（带全集工具）
             model_round = await self.io.call_llm(
                 messages=self.messages,
                 tools=self.tools or None,  # 不再按 intent 限制
-                tool_use_policy=self.active_policy,
+                tool_use_policy=round_policy,
                 react_round_index=round_idx,
             )
             self._apply_model_round(model_round, replace_totals=(round_idx == 0))

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -757,6 +757,7 @@ class _TurnRunLoop:
                 messages=self.messages,
                 tools=self.tools or None,  # 不再按 intent 限制
                 tool_use_policy=self.active_policy,
+                react_round_index=round_idx,
             )
             self._apply_model_round(model_round, replace_totals=(round_idx == 0))
 

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal, Protocol
@@ -498,6 +499,8 @@ class _TurnRunLoop:
     completion_tokens_used: int = field(init=False, default=0)
     decision: RecoveryDecision | None = field(init=False, default=None)
     ran_post_tool_follow_up: bool = field(init=False, default=False)
+    empty_action_nudged: bool = field(init=False, default=False)
+    previous_tool_call_signature: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         self.messages = self.prep.messages
@@ -662,8 +665,9 @@ class _TurnRunLoop:
         if shortcircuit_applied:
             # 确定性短路设置了 synthetic response，需要执行工具
             if getattr(self.response, "tool_calls", None):
+                # 工具轮次由 execute_tool_batch 内的 delta 计数统一注册，
+                # 此处不再显式 register_tool_round，避免预算双计。
                 await self._execute_tool_batch_in_loop()
-                self.state.register_tool_round()
                 sc_kind = self.state.preparation_diagnostics.get(
                     "deterministic_shortcircuit_intent_kind"
                 )
@@ -671,6 +675,7 @@ class _TurnRunLoop:
                     # confirmation_replay 执行完写操作后，进入完整 ReAct 循环
                     # 让 LLM 用全集工具继续后续步骤（如创建后发布）
                     self._restore_full_tools_for_react()
+                    self._inject_replay_continuation_guidance()
                     await self._run_react_loop()
                 # time_query 等短路工具结果即最终回复，无需额外处理
             return await self._finalize_result()
@@ -724,6 +729,119 @@ class _TurnRunLoop:
             allowed_tool_names=all_tool_names,
             retry_on_contract_breach=True,
             reason="confirmation_replay_post_react_full_tools",
+        )
+
+    def _inject_replay_continuation_guidance(self) -> None:
+        """confirmation_replay 续跑前注入续作引导。
+
+        授权操作执行后，模型常直接输出总结而不继续用户原始请求里的后续步骤
+        （如创建公告后未发布）。注入一条内部 system 引导，提示模型继续执行
+        尚未完成的步骤，全部完成后再用纯文本总结，避免步骤被丢弃。
+        """
+        self.state.preparation_diagnostics["react_replay_continuation_guidance"] = True
+        self.messages.append(
+            ChatMessage(
+                role="system",
+                content=(
+                    "用户先前授权的操作已执行完成。"
+                    "请检查用户的原始请求是否还有尚未完成的后续步骤"
+                    "（例如创建后需要发布、提交或继续下一步操作）；"
+                    "如有，请继续调用相应工具逐步完成，"
+                    "全部步骤完成后再用纯文本总结最终结果；"
+                    "若已全部完成则直接用纯文本总结，不要再调用工具。"
+                ),
+                metadata={"react_replay_continuation_guidance": True},
+                internal_only=True,
+            )
+        )
+
+    def _round_policy_expects_tools(self, round_policy: ToolUsePolicy | None) -> bool:
+        """判断本轮策略是否明确要求使用工具。"""
+        return bool(
+            round_policy is not None
+            and getattr(round_policy, "mode", None) == "required"
+            and self.tools
+        )
+
+    async def _maybe_nudge_empty_action(
+        self,
+        *,
+        round_idx: int,
+        round_policy: ToolUsePolicy | None,
+    ) -> bool:
+        """一次性"空动作"纠偏。
+
+        当首轮策略要求使用工具、本 turn 内尚无任何工具结果，模型却直接返回
+        纯文本时，追加一次引导并重试，避免模型"口头完成"而不实际调用工具。
+        受 1 次上限约束，不会引入新循环。
+        返回 True 表示已注入纠偏、应继续循环重试。
+        """
+        if self.empty_action_nudged:
+            return False
+        if round_idx != 0 or self.tool_results:
+            return False
+        if not self._round_policy_expects_tools(round_policy):
+            return False
+
+        self.empty_action_nudged = True
+        self.state.preparation_diagnostics["react_empty_action_nudged"] = True
+        self.messages.append(
+            ChatMessage(
+                role="system",
+                content=(
+                    "你尚未调用任何工具就给出了文本回复。"
+                    "本次请求需要通过工具来真正完成操作，"
+                    "请先调用合适的工具执行用户请求的操作，"
+                    "所有操作完成后再用纯文本总结结果。"
+                ),
+                metadata={"react_empty_action_nudge": True},
+                internal_only=True,
+            )
+        )
+        return True
+
+    @staticmethod
+    def _tool_calls_signature(response: ChatResponse | None) -> str:
+        """计算一组 tool_calls 的规范化签名（name + 排序后参数）。
+
+        用于检测 ReAct 循环中模型反复发起完全相同的工具调用（无进展）。
+        """
+        tool_calls = getattr(response, "tool_calls", None) or []
+        parts: list[str] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                continue
+            function = tool_call.get("function") or {}
+            name = str(function.get("name") or "").strip()
+            raw_args = function.get("arguments")
+            if isinstance(raw_args, str):
+                try:
+                    parsed_args = json.loads(raw_args) if raw_args.strip() else {}
+                    normalized_args = json.dumps(
+                        parsed_args, sort_keys=True, ensure_ascii=False
+                    )
+                except (ValueError, TypeError):
+                    normalized_args = raw_args.strip()
+            elif raw_args is None:
+                normalized_args = "{}"
+            else:
+                normalized_args = json.dumps(
+                    raw_args, sort_keys=True, ensure_ascii=False, default=str
+                )
+            parts.append(f"{name}:{normalized_args}")
+        return "|".join(sorted(parts))
+
+    def _handle_no_progress_break(self) -> None:
+        """检测到连续相同工具调用（无进展）时中断循环并走 partial 退出。"""
+        self.state.preparation_diagnostics["react_no_progress_break"] = True
+        self.response = ChatResponse(
+            message=ChatMessage(role="assistant", content=""),
+            total_tokens=0,
+            output_tokens=0,
+        )
+        self.decision = RecoveryDecision(
+            action="return_partial",
+            reason="react_no_progress",
         )
 
     def _max_tool_rounds(self) -> int:
@@ -805,25 +923,36 @@ class _TurnRunLoop:
             )
             self._apply_model_round(model_round, replace_totals=(round_idx == 0))
 
-            # 无 tool_calls → 检查 consent gate 然后结束
+            # 无 tool_calls → 先尝试一次性空动作纠偏，再检查 consent gate 然后结束
             if not getattr(self.response, "tool_calls", None):
+                if await self._maybe_nudge_empty_action(
+                    round_idx=round_idx,
+                    round_policy=round_policy,
+                ):
+                    continue
                 # 在纯文本回复后检查 consent gate（可能从恢复场景来）
                 await self._check_consent_gate()
                 return
+
+            # P1-3: 无进展检测——连续两轮发起完全相同的工具调用则中断，
+            # 避免模型卡在重复调用上刷预算（在执行前判断，不产生孤儿调用）。
+            signature = self._tool_calls_signature(self.response)
+            if signature and signature == self.previous_tool_call_signature:
+                self._handle_no_progress_break()
+                return
+            self.previous_tool_call_signature = signature
 
             # 确认门控检查（工具执行前检查）
             if await self._check_consent_gate():
                 return  # 暂停等待用户确认
 
-            # 执行工具批次
+            # 执行工具批次（工具轮次由 execute_tool_batch 内的 delta 计数统一
+            # 注册，不在此处再次显式 register_tool_round，避免预算双计）
             await self._execute_tool_batch_in_loop()
 
             # 工具执行后再次检查确认门控
             if await self._check_consent_gate():
                 return
-
-            # 注册工具轮次
-            self.state.register_tool_round()
 
         # 循环结束但仍有 tool_calls，说明预算耗尽
         budget_exit = self.state.budget_exit_reason() or "tool_round_budget_exceeded"

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -664,13 +664,14 @@ class _TurnRunLoop:
             if getattr(self.response, "tool_calls", None):
                 await self._execute_tool_batch_in_loop()
                 self.state.register_tool_round()
-                # 仅 confirmation_replay 写操作执行后需要 LLM 总结
-                # time_query 等短路工具结果即最终回复，无需 LLM
                 sc_kind = self.state.preparation_diagnostics.get(
                     "deterministic_shortcircuit_intent_kind"
                 )
                 if sc_kind == "confirmation_replay":
-                    await self._run_shortcircuit_summary()
+                    # confirmation_replay 执行完写操作后，进入完整 ReAct 循环
+                    # 让 LLM 用全集工具继续后续步骤（如创建后发布）
+                    await self._run_react_loop()
+                # time_query 等短路工具结果即最终回复，无需额外处理
             return await self._finalize_result()
 
         await self._run_react_loop()

--- a/backend/app/ai/engine/turn_executor.py
+++ b/backend/app/ai/engine/turn_executor.py
@@ -663,6 +663,14 @@ class _TurnRunLoop:
             # 确定性短路设置了 synthetic response，需要执行工具
             if getattr(self.response, "tool_calls", None):
                 await self._execute_tool_batch_in_loop()
+                self.state.register_tool_round()
+                # 仅 confirmation_replay 写操作执行后需要 LLM 总结
+                # time_query 等短路工具结果即最终回复，无需 LLM
+                sc_kind = self.state.preparation_diagnostics.get(
+                    "deterministic_shortcircuit_intent_kind"
+                )
+                if sc_kind == "confirmation_replay":
+                    await self._run_shortcircuit_summary()
             return await self._finalize_result()
 
         await self._run_react_loop()
@@ -836,6 +844,32 @@ class _TurnRunLoop:
             self.decision = decision
             return True
         return False
+
+    async def _run_shortcircuit_summary(self) -> None:
+        """短路执行工具后，调用 LLM 生成总结回复。
+
+        confirmation_replay 等写操作在短路路径执行工具后，
+        需要再调一轮 LLM 生成人类可读的总结回复。
+        """
+        summary_policy = ToolUsePolicy(
+            family="none",
+            mode="none",
+            allowed_tool_names=[],
+            retry_on_contract_breach=False,
+            reason="shortcircuit_summary",
+        )
+        self.emit_round(
+            round_kind="shortcircuit_summary",
+            policy=summary_policy,
+            tools=[],
+            reason="shortcircuit_post_tool_summary",
+        )
+        model_round = await self.io.call_llm(
+            messages=self.messages,
+            tools=None,
+            tool_use_policy=summary_policy,
+        )
+        self._apply_model_round(model_round, replace_totals=False)
 
     async def _run_initial_round(self) -> None:
         initial_budget_exit = self.state.budget_exit_reason()

--- a/backend/app/ai/engine/turn_flow_projector.py
+++ b/backend/app/ai/engine/turn_flow_projector.py
@@ -577,9 +577,51 @@ def _has_provider_event_kind(diagnostics_payload: dict[str, Any], kind: str) -> 
     )
 
 
+def _react_round_events(
+    turn_events: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Extract turn.round_started events with round_kind='react_round'."""
+    results: list[dict[str, Any]] = []
+    for event in turn_events:
+        if event.get("kind") != "turn.round_started":
+            continue
+        data = _as_dict(event.get("data"))
+        if data.get("round_kind") == "react_round":
+            results.append(event)
+    return results
+
+
 def _tool_selection_stage(
     diagnostics_payload: dict[str, Any],
 ) -> TurnFlowStage:
+    turn_events = _extract_turn_events(diagnostics_payload)
+    react_rounds = _react_round_events(turn_events)
+
+    if react_rounds:
+        # ReAct 模式：LLM 直接获得全集工具，没有显式过滤步骤
+        first_round_data = _as_dict(react_rounds[0].get("data"))
+        tool_names = _as_list(first_round_data.get("tool_names"))
+        all_tools_count = len(tool_names)
+        summary = (
+            f"{all_tools_count} tools available (ReAct)"
+            if all_tools_count > 0
+            else "No tools available"
+        )
+        return TurnFlowStage(
+            id="tool_selection",
+            type="tool_selection",
+            status="completed" if all_tools_count > 0 else "skipped",  # type: ignore[arg-type]
+            title="Tool Selection",
+            summary=summary,
+            detail_lines=[summary],
+            metrics={
+                "all_tools_count": all_tools_count,
+                "candidate_tools_count": all_tools_count,
+                "filtering_reason": "react_full_toolset",
+            },
+        )
+
+    # 传统模式：使用 tool_filtering 诊断数据
     filtering = _as_dict(diagnostics_payload.get("tool_filtering"))
     all_tools_count = _as_int(filtering.get("all_tools_count"), 0)
     candidate_tools_count = _as_int(filtering.get("candidate_tools_count"), 0)
@@ -612,6 +654,13 @@ def _tool_execution_stage(
     round_count = _count_turn_events(turn_events, "turn.tool_round")
     completed_count = _count_turn_events(turn_events, "turn.tool_completed")
     failed_count = _count_turn_events(turn_events, "turn.tool_failed")
+
+    # ReAct 模式：用 react_round 事件补充轮次计数
+    react_rounds = _react_round_events(turn_events)
+    react_round_count = len(react_rounds)
+    if react_round_count > 0:
+        round_count = max(round_count, react_round_count)
+
     normalized_tool_results = [
         _tool_result_payload(result)
         for result in (tool_results or [])
@@ -653,6 +702,7 @@ def _tool_execution_stage(
         metrics={
             "tool_call_count": completed_count + failed_count,
             "tool_rounds": round_count,
+            "react_rounds": react_round_count,
             "completed_tool_calls": completed_count,
             "failed_tool_calls": failed_count,
         },
@@ -1060,6 +1110,46 @@ def build_tool_execution_result_event(
     )
 
 
+def build_react_round_started_event(
+    *,
+    round_index: int,
+    tool_count: int = 0,
+) -> list[dict[str, Any]]:
+    """Build turn flow stage events emitted at the start of a ReAct round."""
+    events: list[dict[str, Any]] = [
+        _canonical_stage_event_payload(
+            stage_type="thinking",
+            status="running",
+            title="Thinking",
+            summary=f"ReAct round {round_index + 1}",
+        ),
+    ]
+    if tool_count > 0:
+        events.append(
+            _canonical_stage_event_payload(
+                stage_type="tool_selection",
+                status="running",
+                title="Tool Selection",
+                summary=f"{tool_count} tools available (ReAct)",
+                metrics={
+                    "all_tools_count": tool_count,
+                    "candidate_tools_count": tool_count,
+                },
+            )
+        )
+    return events
+
+
+def build_react_answer_assembly_event() -> dict[str, Any]:
+    """Build answer_assembly stage event when ReAct loop produces final text."""
+    return _canonical_stage_event_payload(
+        stage_type="answer_assembly",
+        status="running",
+        title="Answer Assembly",
+        summary="Synthesizing final answer",
+    )
+
+
 def build_answer_assembly_turn_flow_event() -> dict[str, Any]:
     return _canonical_stage_update_payload(
         stage_type="answer_assembly",
@@ -1107,6 +1197,8 @@ def build_turn_answer_card_event(
 __all__ = [
     "build_answer_assembly_turn_flow_event",
     "build_initial_turn_flow_events",
+    "build_react_answer_assembly_event",
+    "build_react_round_started_event",
     "build_turn_answer_card_event",
     "build_turn_evidence_events",
     "build_turn_evidence_items",

--- a/backend/tests/ai/engine/test_budget_guard_defaults.py
+++ b/backend/tests/ai/engine/test_budget_guard_defaults.py
@@ -12,7 +12,7 @@ from app.ai.engine.budget_guard import BudgetGuard
 def test_fast_budget_uses_provider_tolerant_elapsed_default() -> None:
     budget = BudgetGuard.build_default("fast", intent_count=1)
 
-    assert budget.max_tool_rounds == 2
+    assert budget.max_tool_rounds == 4  # ReAct 循环需要更多轮次
     assert budget.max_completion_tokens == 2000
     assert budget.max_elapsed_ms == 40000
     assert budget.max_retry_per_intent == 1

--- a/backend/tests/ai/engine/test_partial_exit_final_response.py
+++ b/backend/tests/ai/engine/test_partial_exit_final_response.py
@@ -238,7 +238,15 @@ async def test_budget_exit_with_tool_results_uses_cached_partial_output(
         sync_calls["count"] += 1
         if self.budget is None:
             return
-        if sync_calls["count"] >= 2:
+        # Trigger the elapsed stop-loss once the first tool round has completed.
+        # This keeps the tool evidence available for the cached partial output
+        # while preventing the follow-up synthesis LLM call. Driving this off of
+        # tool_rounds_used (instead of a raw sync_elapsed call counter) keeps the
+        # test decoupled from the exact number of internal budget checks.
+        # 在第一个工具轮完成后触发超时止损：保留工具证据用于缓存式部分输出，
+        # 同时阻止后续总结 LLM 调用。以 tool_rounds_used 驱动而非 sync_elapsed
+        # 调用计数，避免与内部预算检查次数耦合。
+        if self.budget.tool_rounds_used >= 1:
             self.budget.elapsed_ms_used = self.budget.max_elapsed_ms + 1
         else:
             self.budget.elapsed_ms_used = 0

--- a/backend/tests/ai/engine/test_turn_executor.py
+++ b/backend/tests/ai/engine/test_turn_executor.py
@@ -400,6 +400,7 @@ async def test_turn_executor_runs_time_shortcircuit_without_provider_call_for_co
 async def test_turn_executor_keeps_post_tool_follow_up_for_non_deterministic_tools() -> (
     None
 ):
+    """验证 ReAct 循环在工具执行后继续调用 LLM 生成最终回复。"""
     tools = [ToolDefinition(name="crm_lookup", description="Lookup CRM record")]
     intents = [
         IntentPlan(
@@ -465,13 +466,13 @@ async def test_turn_executor_keeps_post_tool_follow_up_for_non_deterministic_too
         agent=SimpleNamespace(id=1),
     )
 
+    # ReAct 循环：第 1 次 LLM 调用返回 tool_calls，第 2 次返回纯文本
     assert result.output == "客户状态是 active。"
     assert len(io.call_history) == 2
-    assert io.call_history[1]["breach_retry_result"] == "normal_follow_up_round"
-    assert io.call_history[1]["tools"] is None
+    # ReAct 循环中第 2 次调用是普通轮次，不需要 normal_follow_up_round 标记
     assert any(
         event.kind == "turn.round_started"
-        and event.data.get("round_kind") == "normal_follow_up_round"
+        and event.data.get("round_kind") == "react_round"
         for event in state.turn_events
     )
 
@@ -480,6 +481,7 @@ async def test_turn_executor_keeps_post_tool_follow_up_for_non_deterministic_too
 async def test_turn_executor_requests_weather_city_before_tool_retry_when_city_missing() -> (
     None
 ):
+    """验证 ReAct 循环中缺失参数澄清仍然工作。"""
     tools = [ToolDefinition(name="get_current_weather", description="Weather")]
     intents = [
         IntentPlan(
@@ -523,8 +525,9 @@ async def test_turn_executor_requests_weather_city_before_tool_retry_when_city_m
         agent=SimpleNamespace(id=1),
     )
 
+    # ReAct 循环中缺失参数澄清仍然工作
     assert result.output == "你想查询哪个城市的天气？"
     assert len(io.call_history) == 1
     assert io.call_history[0]["tools"] is None
-    assert io.call_history[0]["breach_retry_result"] == "intent_retry"
+    # ReAct 循环中不再使用 intent_retry 标记，而是通过短路处理
     assert state.intent_plan[0].status == "completed"

--- a/backend/tests/ai/engine/test_turn_executor.py
+++ b/backend/tests/ai/engine/test_turn_executor.py
@@ -39,12 +39,14 @@ class _FakeIOAdapter:
             ToolUsePolicy | None,
             dict[str, object],
         ] = (None, None, {}),
+        consent_payloads: list[dict[str, object] | None] | None = None,
     ) -> None:
         self.model_rounds = list(model_rounds)
         self.tool_batch = tool_batch or ToolBatchResult(response=None, tool_results=[])
         self.tool_batches = list(tool_batches or [])
         self.contract_retry = contract_retry
         self.post_tool_contract_breach = post_tool_contract_breach
+        self.consent_payloads = list(consent_payloads or [])
         self.call_history: list[dict[str, object]] = []
         self.retry_logs: list[str] = []
         self.finalize_calls: list[dict[str, object]] = []
@@ -58,7 +60,43 @@ class _FakeIOAdapter:
         return self.model_rounds.pop(0)
 
     async def handle_tool_calls(self, **kwargs):
+        call_index = len(self.tool_call_history)
         self.tool_call_history.append(dict(kwargs))
+        # Mirror production: handle_tool_calls appends one assistant tool_call
+        # message per round so delta-based tool-round counting works correctly.
+        # 贴合真实运行：每轮 append 一条 assistant tool_call 消息，使基于 delta
+        # 的工具轮次计数生效（否则测试无法发现轮次双计/漏计问题）。
+        messages = kwargs.get("messages")
+        response = kwargs.get("response")
+        tool_calls = (
+            getattr(response, "tool_calls", None) if response is not None else None
+        )
+        if isinstance(messages, list) and tool_calls:
+            messages.append(
+                ChatMessage(
+                    role="assistant",
+                    content="",
+                    tool_calls=list(tool_calls),
+                )
+            )
+        # Simulate a consent gate for this batch by appending a pending_consent
+        # message, mirroring the real tool processor's consent_ask behavior.
+        # 模拟该批次命中 consent 门控：append 一条带 pending_consent 的消息，
+        # 贴合真实工具处理器的 consent_ask 行为，用于验证 ReAct 暂停/恢复。
+        consent_payload = (
+            self.consent_payloads[call_index]
+            if call_index < len(self.consent_payloads)
+            else None
+        )
+        if isinstance(messages, list) and consent_payload:
+            messages.append(
+                ChatMessage(
+                    role="tool",
+                    content="",
+                    tool_call_id="consent_tc",
+                    metadata={"pending_consent": dict(consent_payload)},
+                )
+            )
         if self.tool_batches:
             return self.tool_batches.pop(0)
         return self.tool_batch
@@ -531,3 +569,317 @@ async def test_turn_executor_requests_weather_city_before_tool_retry_when_city_m
     assert io.call_history[0]["tools"] is None
     # ReAct 循环中不再使用 intent_retry 标记，而是通过短路处理
     assert state.intent_plan[0].status == "completed"
+
+
+def _tool_call(name: str, *, call_id: str, arguments: str = "{}") -> dict[str, object]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _crm_prep():
+    tools = [ToolDefinition(name="crm_lookup", description="Lookup CRM record")]
+    intents = [
+        IntentPlan(
+            intent_id="intent-crm",
+            kind="crm_lookup",
+            family="crm",
+            order=1,
+            user_visible_label="CRM lookup",
+            source_text="查一下客户状态",
+            allowed_tool_names=["crm_lookup"],
+            preferred_tool_names=["crm_lookup"],
+        )
+    ]
+    return _build_prep(
+        tools=tools,
+        intents=intents,
+        tool_use_policy=ToolUsePolicy(
+            family="crm",
+            mode="required",
+            allowed_tool_names=["crm_lookup"],
+            retry_on_contract_breach=False,
+            reason="crm_lookup",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_round_counts_single_tool_round_no_double_count() -> None:
+    """P0-1: 每个 ReAct 工具轮次只计 1 次，不再双计预算。"""
+    prep = _crm_prep()
+    state = ExecutionStateMachine.from_prepared_execution(prep)
+    io = _FakeIOAdapter(
+        model_rounds=[
+            _assistant_response("", tool_calls=[_tool_call("crm_lookup", call_id="c1")]),
+            _assistant_response("客户状态是 active。"),
+        ],
+        tool_batch=ToolBatchResult(
+            response=None,
+            tool_results=[
+                ToolResult(
+                    tool_call_id="c1",
+                    name="crm_lookup",
+                    success=True,
+                    output="active",
+                )
+            ],
+            total_tokens=7,
+            completion_tokens_used=7,
+        ),
+    )
+
+    result = await TurnExecutor.run(
+        state=state,
+        io=io,
+        prep=prep,
+        request=SimpleNamespace(input_variables={}, conversation_id=30),
+        agent=SimpleNamespace(id=1),
+    )
+
+    assert result.output == "客户状态是 active。"
+    # 一轮工具调用 + 一轮纯文本，工具轮次恰好计 1 次（双计时会是 2）。
+    assert state.budget is not None
+    assert state.budget.tool_rounds_used == 1
+
+
+@pytest.mark.asyncio
+async def test_react_no_progress_break_on_repeated_tool_call() -> None:
+    """P1-3: 连续两轮完全相同的工具调用应中断循环并走 partial。"""
+    prep = _crm_prep()
+    state = ExecutionStateMachine.from_prepared_execution(prep)
+    io = _FakeIOAdapter(
+        model_rounds=[
+            _assistant_response("", tool_calls=[_tool_call("crm_lookup", call_id="a")]),
+            _assistant_response("", tool_calls=[_tool_call("crm_lookup", call_id="b")]),
+        ],
+        tool_batch=ToolBatchResult(
+            response=None,
+            tool_results=[
+                ToolResult(
+                    tool_call_id="a",
+                    name="crm_lookup",
+                    success=True,
+                    output="active",
+                )
+            ],
+            total_tokens=4,
+            completion_tokens_used=4,
+        ),
+    )
+
+    result = await TurnExecutor.run(
+        state=state,
+        io=io,
+        prep=prep,
+        request=SimpleNamespace(input_variables={}, conversation_id=31),
+        agent=SimpleNamespace(id=1),
+    )
+
+    assert result.partial is True
+    assert state.preparation_diagnostics.get("react_no_progress_break") is True
+    # 第 2 轮检测到重复签名后在执行前中断：恰好 2 次 LLM 调用、1 次工具执行。
+    assert len(io.call_history) == 2
+    assert len(io.tool_call_history) == 1
+
+
+@pytest.mark.asyncio
+async def test_react_empty_action_nudge_retries_once() -> None:
+    """P0-2: required 策略下模型口头完成（无工具调用）应被纠偏并重试一次。"""
+    prep = _crm_prep()
+    state = ExecutionStateMachine.from_prepared_execution(prep)
+    io = _FakeIOAdapter(
+        model_rounds=[
+            _assistant_response("好的，我已经帮你查好了。"),
+            _assistant_response("", tool_calls=[_tool_call("crm_lookup", call_id="x")]),
+            _assistant_response("客户状态是 active。"),
+        ],
+        tool_batch=ToolBatchResult(
+            response=None,
+            tool_results=[
+                ToolResult(
+                    tool_call_id="x",
+                    name="crm_lookup",
+                    success=True,
+                    output="active",
+                )
+            ],
+            total_tokens=5,
+            completion_tokens_used=5,
+        ),
+    )
+
+    result = await TurnExecutor.run(
+        state=state,
+        io=io,
+        prep=prep,
+        request=SimpleNamespace(input_variables={}, conversation_id=32),
+        agent=SimpleNamespace(id=1),
+    )
+
+    assert state.preparation_diagnostics.get("react_empty_action_nudged") is True
+    assert result.output == "客户状态是 active。"
+    # 空动作纠偏触发一次重试：text → (nudge) → tool → text，共 3 次 LLM 调用。
+    assert len(io.call_history) == 3
+
+
+def _confirmation_replay_prep():
+    tools = [
+        ToolDefinition(name="create_announcement", description="Create announcement"),
+        ToolDefinition(name="publish_announcement", description="Publish announcement"),
+    ]
+    intents = [
+        IntentPlan(
+            intent_id="intent-replay",
+            kind="confirmation_replay",
+            family="internal_ops",
+            order=1,
+            user_visible_label="确认重放",
+            source_text="创建公告后直接发布",
+            shortcircuit=True,
+            allowed_tool_names=["create_announcement"],
+            preferred_tool_names=["create_announcement"],
+            metadata={
+                "confirmation_replay": {
+                    "name": "create_announcement",
+                    "tool_call_id": "tc_create",
+                    "arguments": "{}",
+                }
+            },
+        )
+    ]
+    return _build_prep(
+        tools=tools,
+        intents=intents,
+        tool_use_policy=ToolUsePolicy(
+            family="internal_ops",
+            mode="required",
+            allowed_tool_names=["create_announcement"],
+            retry_on_contract_breach=False,
+            reason="confirmation_replay",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirmation_replay_injects_continuation_guidance_and_continues() -> None:
+    """P0-2: confirmation_replay 续跑前注入引导，并由 ReAct 循环继续后续步骤。"""
+    prep = _confirmation_replay_prep()
+    state = ExecutionStateMachine.from_prepared_execution(prep)
+    io = _FakeIOAdapter(
+        model_rounds=[
+            # 续跑：模型继续发起 publish，再以纯文本总结
+            _assistant_response(
+                "", tool_calls=[_tool_call("publish_announcement", call_id="tc_pub")]
+            ),
+            _assistant_response("公告已创建并发布。"),
+        ],
+        tool_batches=[
+            # call 0: confirmation_replay 执行 create
+            ToolBatchResult(
+                response=None,
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="tc_create",
+                        name="create_announcement",
+                        success=True,
+                        output='{"id": 11, "status": "draft"}',
+                    )
+                ],
+                total_tokens=3,
+                completion_tokens_used=3,
+            ),
+            # call 1: 续跑执行 publish
+            ToolBatchResult(
+                response=None,
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="tc_pub",
+                        name="publish_announcement",
+                        success=True,
+                        output='{"id": 11, "status": "published"}',
+                    )
+                ],
+                total_tokens=3,
+                completion_tokens_used=3,
+            ),
+        ],
+    )
+
+    result = await TurnExecutor.run(
+        state=state,
+        io=io,
+        prep=prep,
+        request=SimpleNamespace(input_variables={}, conversation_id=33),
+        agent=SimpleNamespace(id=1),
+    )
+
+    assert (
+        state.preparation_diagnostics.get("react_replay_continuation_guidance") is True
+    )
+    # 续跑引导消息已注入到对话中
+    assert any(
+        message.role == "system"
+        and (message.metadata or {}).get("react_replay_continuation_guidance")
+        for message in prep.messages
+    )
+    # create（短路）+ publish（续跑）两次工具批次都被执行
+    assert len(io.tool_call_history) == 2
+    assert result.output == "公告已创建并发布。"
+
+
+@pytest.mark.asyncio
+async def test_confirmation_replay_continuation_pauses_for_second_consent() -> None:
+    """链式敏感操作：replay 写入后续跑命中第二次 consent，应再次暂停。"""
+    prep = _confirmation_replay_prep()
+    state = ExecutionStateMachine.from_prepared_execution(prep)
+    io = _FakeIOAdapter(
+        model_rounds=[
+            _assistant_response(
+                "", tool_calls=[_tool_call("publish_announcement", call_id="tc_pub")]
+            ),
+        ],
+        tool_batches=[
+            ToolBatchResult(
+                response=None,
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="tc_create",
+                        name="create_announcement",
+                        success=True,
+                        output='{"id": 12, "status": "draft"}',
+                    )
+                ],
+                total_tokens=3,
+                completion_tokens_used=3,
+            ),
+            ToolBatchResult(
+                response=None,
+                tool_results=[],
+                total_tokens=2,
+                completion_tokens_used=2,
+            ),
+        ],
+        # call 0 (create replay) 无 consent；call 1 (publish) 命中 consent
+        consent_payloads=[
+            None,
+            {
+                "tool_name": "publish_announcement",
+                "action": "tool_consent",
+                "resolved": False,
+            },
+        ],
+    )
+
+    result = await TurnExecutor.run(
+        state=state,
+        io=io,
+        prep=prep,
+        request=SimpleNamespace(input_variables={}, conversation_id=34),
+        agent=SimpleNamespace(id=1),
+    )
+
+    assert result.paused_for_consent is True
+    assert result.partial is False

--- a/backend/tests/ai/engine/test_turn_flow_projector.py
+++ b/backend/tests/ai/engine/test_turn_flow_projector.py
@@ -582,3 +582,177 @@ def test_build_turn_flow_view_model_strips_trace_id_suffix_from_error_surface() 
 
     assert turn_flow["answer_card"]["summary"] == "AI 供应商服务端错误"
     assert turn_flow["error_surface"]["message"] == "AI 供应商服务端错误"
+
+
+# --- ReAct round projection tests ---
+
+
+build_react_round_started_event = (
+    turn_flow_projector.build_react_round_started_event
+)
+build_react_answer_assembly_event = (
+    turn_flow_projector.build_react_answer_assembly_event
+)
+
+
+def test_react_round_projects_tool_selection_from_round_events() -> None:
+    """ReAct 多轮执行时，tool_selection stage 从 react_round 事件导出。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {
+                        "round_kind": "react_round",
+                        "tool_names": ["get_weather", "search_kb", "memory_save"],
+                    },
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 500,
+                    "data": {
+                        "round_kind": "react_round",
+                        "tool_names": ["get_weather", "search_kb", "memory_save"],
+                    },
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=[
+            {
+                "name": "get_weather",
+                "success": True,
+                "output": "北京晴",
+                "tool_call_id": "tc_1",
+            },
+            {
+                "name": "search_kb",
+                "success": True,
+                "output": "KB result",
+                "tool_call_id": "tc_2",
+            },
+        ],
+        output="北京今天晴天。",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_selection_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_selection"
+    )
+    assert tool_selection_stage["status"] == "completed"
+    assert tool_selection_stage["metrics"]["all_tools_count"] == 3
+    assert tool_selection_stage["metrics"]["filtering_reason"] == "react_full_toolset"
+
+
+def test_react_round_projects_tool_execution_with_react_round_count() -> None:
+    """ReAct 多轮执行时，tool_execution stage 正确聚合 react_round 轮次。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 200,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 400,
+                    "data": {"round_kind": "react_round", "tool_names": ["a", "b"]},
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=[
+            {"name": "a", "success": True, "output": "r1", "tool_call_id": "tc_1"},
+            {"name": "b", "success": True, "output": "r2", "tool_call_id": "tc_2"},
+            {"name": "a", "success": False, "error": "timeout", "tool_call_id": "tc_3"},
+        ],
+        output="最终答案",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_execution_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_execution"
+    )
+    assert tool_execution_stage["metrics"]["react_rounds"] == 3
+    assert tool_execution_stage["metrics"]["tool_call_count"] == 3
+    assert tool_execution_stage["metrics"]["completed_tool_calls"] == 2
+    assert tool_execution_stage["metrics"]["failed_tool_calls"] == 1
+    assert tool_execution_stage["status"] == "error"  # 有失败的工具
+
+
+def test_build_react_round_started_event_emits_thinking_and_tool_selection() -> None:
+    """build_react_round_started_event 发出 thinking 和 tool_selection 阶段事件。"""
+    events = build_react_round_started_event(round_index=0, tool_count=5)
+
+    assert len(events) == 2
+    thinking_event = events[0]
+    assert thinking_event["stage"]["type"] == "thinking"
+    assert thinking_event["stage"]["status"] == "running"
+    assert "ReAct round 1" in thinking_event["stage"]["summary"]
+
+    selection_event = events[1]
+    assert selection_event["stage"]["type"] == "tool_selection"
+    assert selection_event["stage"]["status"] == "running"
+    assert selection_event["stage"]["metrics"]["all_tools_count"] == 5
+
+
+def test_build_react_round_started_event_skips_tool_selection_when_no_tools() -> None:
+    """没有工具时只发出 thinking 事件。"""
+    events = build_react_round_started_event(round_index=2, tool_count=0)
+
+    assert len(events) == 1
+    assert events[0]["stage"]["type"] == "thinking"
+
+
+def test_build_react_answer_assembly_event_emits_stage() -> None:
+    """build_react_answer_assembly_event 发出 answer_assembly 阶段事件。"""
+    event = build_react_answer_assembly_event()
+    assert event["stage"]["type"] == "answer_assembly"
+    assert event["stage"]["status"] == "running"
+    assert "Synthesizing" in event["stage"]["summary"]
+
+
+def test_react_round_tool_selection_skipped_when_no_tools_available() -> None:
+    """ReAct 模式且无工具时，tool_selection stage 应为 skipped。"""
+    turn_flow = build_turn_flow_view_model(
+        diagnostics_payload={
+            "turn_events": [
+                {
+                    "kind": "turn.round_started",
+                    "timestamp_ms": 10,
+                    "data": {"round_kind": "react_round", "tool_names": []},
+                },
+            ],
+        },
+        turn_record={"termination_reason": "completed"},
+        rag_sources=[],
+        tool_results=None,
+        output="纯文本回复",
+        completion_reason="completed",
+        interrupted=False,
+        error=None,
+    )
+
+    tool_selection_stage = next(
+        stage
+        for stage in turn_flow["timeline"]
+        if stage.get("type") == "tool_selection"
+    )
+    assert tool_selection_stage["status"] == "skipped"

--- a/frontend/apps/web-antd/src/components/business/ai-chat-kernel/ActionConsentGate.vue
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-kernel/ActionConsentGate.vue
@@ -7,7 +7,7 @@ import type {
   ToolApprovalPresentationTarget,
 } from '#/types/ai-chat';
 
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import { IconifyIcon } from '@vben/icons';
 
@@ -17,12 +17,16 @@ const props = withDefaults(
   defineProps<{
     action?: KernelPendingActionState | null;
     compact?: boolean;
+    floating?: boolean;
   }>(),
   {
     action: null,
     compact: false,
+    floating: false,
   },
 );
+
+const floatingDetailsExpanded = ref(false);
 
 const emit = defineEmits<{
   approve: [];
@@ -318,11 +322,151 @@ const resolvedLabel = computed(() => {
   }
   return $t('common.globalAiChat.consentApproved');
 });
+
+const hasExpandableContent = computed(() => {
+  return (
+    presentationMetaItems.value.length > 0 ||
+    presentationDetails.value.length > 0 ||
+    fallbackPreviewEntries.value.length > 0 ||
+    !!technicalPayload.value ||
+    !!consentArguments.value
+  );
+});
 </script>
 
 <template>
+  <!-- Floating mode: compact card anchored to bottom input area -->
   <div
-    v-if="action"
+    v-if="action && floating"
+    data-testid="chat-message-kernel-consent-floating"
+    class="ai-consent-floating overflow-hidden rounded-xl border border-warning/40 bg-background shadow-lg"
+  >
+    <!-- Compact header: icon + operation title -->
+    <div class="flex min-w-0 items-center gap-2 px-3 py-2">
+      <IconifyIcon
+        :icon="
+          action.kind === 'confirmation'
+            ? 'lucide:shield-question'
+            : 'lucide:shield-alert'
+        "
+        class="size-3.5 shrink-0 text-warning"
+      />
+      <span class="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+        {{ actionLabel || $t(titleKey) }}
+      </span>
+      <button
+        v-if="hasExpandableContent"
+        class="inline-flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        @click="floatingDetailsExpanded = !floatingDetailsExpanded"
+      >
+        <IconifyIcon
+          :icon="floatingDetailsExpanded ? 'lucide:chevron-up' : 'lucide:chevron-down'"
+          class="size-3"
+        />
+        {{ floatingDetailsExpanded ? $t('common.globalAiChat.collapseDetails') : $t('common.globalAiChat.expandDetails') }}
+      </button>
+    </div>
+
+    <!-- Expandable details section -->
+    <Transition name="ai-consent-details">
+      <div
+        v-if="floatingDetailsExpanded"
+        class="max-h-48 overflow-y-auto border-t border-border/20 px-3 py-2"
+      >
+        <div class="space-y-2">
+          <div
+            v-if="presentationMetaItems.length > 0"
+            data-testid="approval-presentation-meta"
+            class="flex min-w-0 flex-wrap gap-1"
+          >
+            <span
+              v-for="item in presentationMetaItems"
+              :key="item.key"
+              class="inline-flex min-w-0 max-w-full items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px]"
+              :class="[
+                item.key === 'risk'
+                  ? riskToneClass(item.tone)
+                  : 'border-border/40 bg-accent/40 text-muted-foreground',
+              ]"
+            >
+              <span class="shrink-0 text-muted-foreground/70">{{ item.label }}</span>
+              <span class="min-w-0 break-words font-medium text-foreground/80">{{ item.value }}</span>
+            </span>
+          </div>
+
+          <dl
+            v-if="presentationDetails.length > 0"
+            data-testid="approval-presentation-details"
+            class="min-w-0 divide-y divide-border/30 overflow-hidden rounded-md border border-border/40 bg-accent/30 text-[10px]"
+          >
+            <div
+              v-for="item in presentationDetails"
+              :key="item.key"
+              class="grid min-w-0 grid-cols-[minmax(0,0.42fr)_minmax(0,0.58fr)] gap-2 px-2 py-1"
+            >
+              <dt class="min-w-0 break-words font-medium text-foreground/70">{{ item.label }}</dt>
+              <dd class="min-w-0 break-words text-muted-foreground">{{ item.value }}</dd>
+            </div>
+          </dl>
+
+          <div
+            v-if="fallbackPreviewEntries.length > 0"
+            data-testid="approval-fallback-preview"
+            class="max-h-24 overflow-y-auto rounded-md bg-accent/50 px-2 py-1.5 text-[10px]"
+          >
+            <table class="w-full table-fixed text-left">
+              <tr
+                v-for="[key, value] in fallbackPreviewEntries"
+                :key="String(key)"
+                class="border-b border-border/30 last:border-0"
+              >
+                <td class="w-[38%] break-words py-0.5 pr-3 align-top font-medium text-foreground/70">
+                  {{ key }}
+                </td>
+                <td class="break-words py-0.5 text-muted-foreground">
+                  {{ typeof value === 'object' ? JSON.stringify(value) : value }}
+                </td>
+              </tr>
+            </table>
+          </div>
+
+          <details
+            v-if="technicalPayload"
+            data-testid="approval-technical-details"
+            class="[&>summary::-webkit-details-marker]:hidden [&>summary]:list-none"
+          >
+            <summary class="flex cursor-pointer items-center gap-1 text-[10px] text-muted-foreground/70 hover:text-muted-foreground">
+              <IconifyIcon icon="lucide:code" class="size-3" />
+              {{ $t('common.globalAiChat.approvalTechnicalDetails') }}
+            </summary>
+            <pre class="mt-1 max-h-20 overflow-y-auto whitespace-pre-wrap rounded bg-accent/40 px-1.5 py-1 font-mono text-[10px] text-muted-foreground">{{ JSON.stringify(technicalPayload, null, 2) }}</pre>
+          </details>
+        </div>
+      </div>
+    </Transition>
+
+    <!-- Action buttons -->
+    <div class="flex items-center gap-2 border-t border-border/20 px-3 py-2">
+      <button
+        class="inline-flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-2.5 py-1.5 text-[11px] font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+        @click="emit('approve')"
+      >
+        <IconifyIcon icon="lucide:check" class="size-3" />
+        {{ $t(approveKey) }}
+      </button>
+      <button
+        class="inline-flex flex-1 items-center justify-center gap-1 rounded-md border border-border/60 px-2.5 py-1.5 text-[11px] text-muted-foreground transition-colors hover:border-destructive/40 hover:text-destructive"
+        @click="emit('reject')"
+      >
+        <IconifyIcon icon="lucide:x" class="size-3" />
+        {{ $t(rejectKey) }}
+      </button>
+    </div>
+  </div>
+
+  <!-- Inline mode: original card (for resolved state or non-floating) -->
+  <div
+    v-else-if="action"
     data-testid="chat-message-kernel-consent"
     class="overflow-hidden rounded-lg border"
     :class="[
@@ -402,12 +546,8 @@ const resolvedLabel = computed(() => {
               : 'border-border/40 bg-accent/40 text-muted-foreground',
           ]"
         >
-          <span class="shrink-0 text-muted-foreground/70">
-            {{ item.label }}
-          </span>
-          <span class="min-w-0 break-words font-medium text-foreground/80">
-            {{ item.value }}
-          </span>
+          <span class="shrink-0 text-muted-foreground/70">{{ item.label }}</span>
+          <span class="min-w-0 break-words font-medium text-foreground/80">{{ item.value }}</span>
         </span>
       </div>
 
@@ -436,12 +576,8 @@ const resolvedLabel = computed(() => {
           :key="item.key"
           class="grid min-w-0 grid-cols-[minmax(0,0.42fr)_minmax(0,0.58fr)] gap-2 px-2 py-1.5"
         >
-          <dt class="min-w-0 break-words font-medium text-foreground/70">
-            {{ item.label }}
-          </dt>
-          <dd class="min-w-0 break-words text-muted-foreground">
-            {{ item.value }}
-          </dd>
+          <dt class="min-w-0 break-words font-medium text-foreground/70">{{ item.label }}</dt>
+          <dd class="min-w-0 break-words text-muted-foreground">{{ item.value }}</dd>
         </div>
       </dl>
 
@@ -461,9 +597,7 @@ const resolvedLabel = computed(() => {
             :key="String(key)"
             class="border-b border-border/30 last:border-0"
           >
-            <td
-              class="w-[38%] break-words py-0.5 pr-3 align-top font-medium text-foreground/70"
-            >
+            <td class="w-[38%] break-words py-0.5 pr-3 align-top font-medium text-foreground/70">
               {{ key }}
             </td>
             <td class="break-words py-0.5 text-muted-foreground">
@@ -485,10 +619,7 @@ const resolvedLabel = computed(() => {
           <IconifyIcon icon="lucide:code" class="size-3" />
           {{ $t('common.globalAiChat.approvalTechnicalDetails') }}
         </summary>
-        <pre
-          class="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap rounded bg-accent/40 px-1.5 py-1 font-mono text-[10px] text-muted-foreground"
-          >{{ JSON.stringify(technicalPayload, null, 2) }}</pre
-        >
+        <pre class="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap rounded bg-accent/40 px-1.5 py-1 font-mono text-[10px] text-muted-foreground">{{ JSON.stringify(technicalPayload, null, 2) }}</pre>
       </details>
 
       <details
@@ -502,10 +633,7 @@ const resolvedLabel = computed(() => {
           <IconifyIcon icon="lucide:code" class="size-3" />
           {{ $t('common.globalAiChat.consentShowArgs') }}
         </summary>
-        <pre
-          class="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap rounded bg-accent/40 px-1.5 py-1 font-mono text-[10px] text-muted-foreground"
-          >{{ JSON.stringify(consentArguments, null, 2) }}</pre
-        >
+        <pre class="mt-1 max-h-24 overflow-y-auto whitespace-pre-wrap rounded bg-accent/40 px-1.5 py-1 font-mono text-[10px] text-muted-foreground">{{ JSON.stringify(consentArguments, null, 2) }}</pre>
       </details>
 
       <div v-if="!action.resolved" class="flex items-center gap-2">
@@ -527,3 +655,23 @@ const resolvedLabel = computed(() => {
     </div>
   </div>
 </template>
+
+<style scoped>
+.ai-consent-details-enter-active,
+.ai-consent-details-leave-active {
+  transition: all 0.2s ease;
+  overflow: hidden;
+}
+
+.ai-consent-details-enter-from,
+.ai-consent-details-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+
+.ai-consent-details-enter-to,
+.ai-consent-details-leave-from {
+  opacity: 1;
+  max-height: 200px;
+}
+</style>

--- a/frontend/apps/web-antd/src/components/business/ai-chat-kernel/ChatMessageKernel.vue
+++ b/frontend/apps/web-antd/src/components/business/ai-chat-kernel/ChatMessageKernel.vue
@@ -454,22 +454,6 @@ watch(canCollapseKernel, (collapsible) => {
 onBeforeUnmount(() => {
   clearKernelAutoCollapseTimer();
 });
-
-function handleApprove() {
-  if (resolvedState.value.pendingAction?.kind === 'confirmation') {
-    emit('confirm');
-    return;
-  }
-  emit('consentConfirm');
-}
-
-function handleReject() {
-  if (resolvedState.value.pendingAction?.kind === 'confirmation') {
-    emit('reject');
-    return;
-  }
-  emit('consentReject');
-}
 </script>
 
 <template>
@@ -648,11 +632,11 @@ function handleReject() {
       />
     </div>
 
+    <!-- Inline card only shown when resolved; pending state is shown as floating card -->
     <ActionConsentGate
+      v-if="resolvedState.pendingAction?.resolved"
       :action="resolvedState.pendingAction"
       :compact="compact"
-      @approve="handleApprove"
-      @reject="handleReject"
     />
     <slot name="diagnostics"></slot>
   </div>

--- a/frontend/apps/web-antd/src/components/business/ai-slide-panel/AIChatPanelBody.vue
+++ b/frontend/apps/web-antd/src/components/business/ai-slide-panel/AIChatPanelBody.vue
@@ -9,8 +9,11 @@ import type {
   ChatMessage,
 } from '#/types/ai-chat';
 
-import { ref, watch } from 'vue';
+import type { KernelPendingActionState } from '#/components/business/ai-chat-kernel/TurnFlowState';
 
+import { computed, ref, watch } from 'vue';
+
+import ActionConsentGate from '#/components/business/ai-chat-kernel/ActionConsentGate.vue';
 import AIChatComposer from './AIChatComposer.vue';
 import AIChatConversationFooter from './AIChatConversationFooter.vue';
 import AIChatHistoryPane from './AIChatHistoryPane.vue';
@@ -203,6 +206,63 @@ const emit = defineEmits<{
 
 const panelBodyRoot = ref<HTMLDivElement | null>(null);
 
+/** Find the first unresolved pending action across messages */
+const activePendingAction = computed<{ action: KernelPendingActionState; index: number } | null>(() => {
+  for (let i = props.chatMessages.length - 1; i >= 0; i--) {
+    const msg = props.chatMessages[i];
+    if (!msg) continue;
+    if (msg.pendingConfirmation && !msg.pendingConfirmation.resolved) {
+      return {
+        action: {
+          action: msg.pendingConfirmation.action,
+          approvalPresentation: msg.pendingConfirmation.approvalPresentation,
+          kind: 'confirmation',
+          preview: msg.pendingConfirmation.preview,
+          resolved: false,
+          table: msg.pendingConfirmation.table,
+          toolName: msg.pendingConfirmation.toolName,
+        },
+        index: i,
+      };
+    }
+    if (msg.pendingConsent && !msg.pendingConsent.resolved) {
+      return {
+        action: {
+          arguments: msg.pendingConsent.arguments,
+          autoApproved: msg.pendingConsent.autoApproved,
+          kind: 'consent',
+          rejected: msg.pendingConsent.rejected,
+          resolved: false,
+          skillName: msg.pendingConsent.skillName,
+          toolName: msg.pendingConsent.toolName,
+        },
+        index: i,
+      };
+    }
+  }
+  return null;
+});
+
+function handleFloatingApprove() {
+  const pending = activePendingAction.value;
+  if (!pending) return;
+  if (pending.action.kind === 'confirmation') {
+    emit('confirm', pending.index);
+  } else {
+    emit('consentConfirm', pending.index);
+  }
+}
+
+function handleFloatingReject() {
+  const pending = activePendingAction.value;
+  if (!pending) return;
+  if (pending.action.kind === 'confirmation') {
+    emit('reject', pending.index);
+  } else {
+    emit('consentReject', pending.index);
+  }
+}
+
 function emitComposerKeydown(event: KeyboardEvent) {
   if (props.welcomeLoading) {
     if (event.key === 'Enter' && !event.shiftKey && !event.isComposing) {
@@ -296,6 +356,18 @@ watch(
         :streaming="streaming"
         :export-menu-items="exportMenuItems"
       />
+
+      <!-- Floating confirmation/consent card above input -->
+      <Transition name="ai-consent-slide">
+        <ActionConsentGate
+          v-if="activePendingAction"
+          :action="activePendingAction.action"
+          :compact="true"
+          :floating="true"
+          @approve="handleFloatingApprove"
+          @reject="handleFloatingReject"
+        />
+      </Transition>
 
       <AIChatComposer
         :model-value="inputMessage"
@@ -407,5 +479,16 @@ watch(
 .ai-chat-history-overlay-leave-to .ai-chat-history-overlay-pane {
   opacity: 0;
   transform: translateY(8px) scale(0.985);
+}
+
+.ai-consent-slide-enter-active,
+.ai-consent-slide-leave-active {
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ai-consent-slide-enter-from,
+.ai-consent-slide-leave-to {
+  opacity: 0;
+  transform: translateY(12px);
 }
 </style>

--- a/frontend/apps/web-antd/src/locales/langs/en-US/common.json
+++ b/frontend/apps/web-antd/src/locales/langs/en-US/common.json
@@ -719,6 +719,8 @@
     "approvalTarget": "Target",
     "approvalDetail": "Detail",
     "approvalTechnicalDetails": "Technical details",
+    "expandDetails": "Show details",
+    "collapseDetails": "Hide details",
     "args": "Input:",
     "noAgentAvailable": "No AI agents available. Please contact admin to configure.",
     "routeFailedHint": "Please select an agent and try again, or send again later.",

--- a/frontend/apps/web-antd/src/locales/langs/zh-CN/common.json
+++ b/frontend/apps/web-antd/src/locales/langs/zh-CN/common.json
@@ -719,6 +719,8 @@
     "approvalTarget": "目标",
     "approvalDetail": "详情",
     "approvalTechnicalDetails": "技术详情",
+    "expandDetails": "展开详情",
+    "collapseDetails": "收起详情",
     "args": "输入：",
     "noAgentAvailable": "暂无可用智能体，请联系管理员配置",
     "routeFailedHint": "请选择智能体后重试，或稍后再次发送。",

--- a/frontend/packages/icons/src/iconify/lucide-subset.generated.ts
+++ b/frontend/packages/icons/src/iconify/lucide-subset.generated.ts
@@ -64,6 +64,7 @@ export const LUCIDE_ICON_NAMES = [
   "chevron-down",
   "chevron-left",
   "chevron-right",
+  "chevron-up",
   "circle",
   "circle-alert",
   "circle-check",
@@ -412,6 +413,7 @@ export const LUCIDE_ICON_IDS = [
   "lucide:chevron-down",
   "lucide:chevron-left",
   "lucide:chevron-right",
+  "lucide:chevron-up",
   "lucide:circle",
   "lucide:circle-alert",
   "lucide:circle-check",
@@ -957,6 +959,9 @@ export const LUCIDE_ICON_SUBSET = {
     },
     "chevron-right": {
       "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"m9 18l6-6l-6-6\"/>"
+    },
+    "chevron-up": {
+      "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"m18 15l-6-6l-6 6\"/>"
     },
     "circle": {
       "body": "<circle cx=\"12\" cy=\"12\" r=\"10\" fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\"/>"


### PR DESCRIPTION
## 变更内容

> 集成分支：在 #50-A / #50-B 基础上叠加 ReAct 多轮循环的一系列稳定性修复，承载「多轮自主执行 + 中途敏感操作弹出用户授权」的完整能力。

本 PR 基于 `test/react-integration`，已合入 #50-A（ReAct 多轮循环）与 #50-B（turn flow 进度投影适配），并在其上完成以下后续修复。

### 核心修复（最新一批）

- **预算双计修复（P0）**：移除 `_run_react_loop` 与 confirmation_replay 短路路径中多余的 `register_tool_round`，统一以 `execute_tool_batch` 的 delta 计数为权威，避免每个工具轮被双计导致多步任务提前 `budget_exit`（即「公告创建成功却停在草稿、未继续发布」的直接根因之一）。
- **口头完成提前退出修复（P0）**：confirmation_replay 续跑前注入续作引导；新增一次性「空动作纠偏」，避免模型不调用工具就口头宣称完成、导致后续步骤（如创建后发布）被丢弃。
- **无进展保护（P1）**：ReAct 循环新增重复 tool_call 签名检测，连续相同则中断走 partial，记录 `react_no_progress_break`，防止刷预算。
- **孤儿 tool_calls 修复（P1）**：consent 门控暂停时裁剪当前待确认工具之后未执行的 tool_calls，并同步修正已追加的 assistant 消息，避免历史重投触发 provider 报错。

### 既有集成内容

- ReAct 多轮自主执行循环（#50-A）与 turn flow 进度投影适配（#50-B）
- confirmation_replay 写操作后进入完整 ReAct 循环、确认门控补充 messages 直接检查、第 2 轮起 tool_choice 改为 auto 等多项 ReAct 稳定性修复
- 前端：悬浮模式确认与同意卡片、ActionConsentGate 适配

### 测试

- `backend/tests/ai/engine`：新增轮次单计、无进展中断、空动作纠偏、replay 续跑引导、链式二次 consent 暂停等用例
- 本地验证：`tests/ai/engine` 全绿（273+），`tests/ai` 全量 509 passed

## 关联

- Refs #50 #55
- 与 #69 / #70 的工作内容已合并入本集成分支（按讨论不直接更新 #69 的分支）

Made with [Cursor](https://cursor.com)