### PR TITLE
fix(internal-ops): 递归展开运行时路由树

### DIFF
--- a/backend/app/ai/internal_ops/catalog.py
+++ b/backend/app/ai/internal_ops/catalog.py
@@ -121,6 +121,44 @@ def _is_excluded_path(path: str) -> bool:
     return any(path.endswith(suffix) for suffix in _EXCLUDED_PATH_SUFFIXES)
 
 
+def _join_paths(prefix: str, path: str) -> str:
+    """Join route path fragments without losing the leading slash."""
+    prefix = str(prefix or "").strip()
+    path = str(path or "").strip()
+    if not prefix and not path:
+        return ""
+    if not prefix:
+        joined = path
+    elif not path:
+        joined = prefix
+    else:
+        joined = f"{prefix.rstrip('/')}/{path.lstrip('/')}"
+    if not joined.startswith("/"):
+        joined = f"/{joined}"
+    return joined
+
+
+def _iter_routes(routes: Any, prefix: str = ""):
+    """
+    Recursively yield concrete routes with their effective path.
+
+    FastAPI/Starlette may keep included routers as nested routing nodes in some
+    runtime versions, so catalog building must not rely on a flat app.routes.
+    """
+    for route in routes or []:
+        route_path = str(getattr(route, "path", "") or "")
+        route_prefix = str(getattr(route, "prefix", "") or "")
+        nested_routes = getattr(route, "routes", None)
+
+        if nested_routes:
+            nested_prefix = _join_paths(prefix, route_path or route_prefix)
+            yield from _iter_routes(nested_routes, nested_prefix)
+            continue
+
+        if route_path:
+            yield route, _join_paths(prefix, route_path)
+
+
 def _annotation_name(annotation: Any) -> str:
     """Best-effort readable type name / 尽力而为的可读类型名"""
     if annotation is None:
@@ -223,8 +261,7 @@ def _build_catalog_from_app(app: Any) -> list[InternalOperation]:
     operations: list[InternalOperation] = []
     seen_ids: set[str] = set()
 
-    for route in getattr(app, "routes", []):
-        path = str(getattr(route, "path", "") or "")
+    for route, path in _iter_routes(getattr(app, "routes", [])):
         methods = getattr(route, "methods", None)
         endpoint = getattr(route, "endpoint", None)
         if not path or not methods or endpoint is None:

--- a/backend/tests/ai/internal_ops/test_catalog_routes.py
+++ b/backend/tests/ai/internal_ops/test_catalog_routes.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from fastapi import APIRouter, FastAPI
+
+from app.ai.internal_ops.catalog import _build_catalog_from_app
+
+
+def _mark_permission(endpoint, resource: str, action: str):
+    endpoint._permission_resource = resource
+    endpoint._permission_action = {"action": action}
+    return endpoint
+
+
+def test_catalog_builds_from_nested_fastapi_routers() -> None:
+    app = FastAPI()
+
+    admin_router = APIRouter()
+    admin_ai_router = APIRouter()
+    tenant_router = APIRouter()
+    user_router = APIRouter()
+
+    @admin_ai_router.get("/agents", summary="List AI agents")
+    async def list_admin_agents() -> dict[str, bool]:
+        return {"ok": True}
+
+    @tenant_router.post("/profiles", summary="Create tenant profile")
+    async def create_tenant_profile() -> dict[str, bool]:
+        return {"ok": True}
+
+    @user_router.get("/me", summary="Get current user")
+    async def get_current_user() -> dict[str, bool]:
+        return {"ok": True}
+
+    _mark_permission(list_admin_agents, "ai_agent", "view")
+    _mark_permission(create_tenant_profile, "tenant_profile", "create")
+    _mark_permission(get_current_user, "user_profile", "view")
+
+    admin_router.include_router(admin_ai_router, prefix="/ai")
+    app.include_router(admin_router, prefix="/admin")
+    app.include_router(tenant_router, prefix="/tenant")
+    app.include_router(user_router, prefix="/api/user")
+
+    operations = _build_catalog_from_app(app)
+
+    by_id = {operation.operation_id: operation for operation in operations}
+    assert set(by_id) == {
+        "GET:/admin/ai/agents",
+        "GET:/api/user/me",
+        "POST:/tenant/profiles",
+    }
+    assert by_id["GET:/admin/ai/agents"].scope == "admin"
+    assert by_id["GET:/admin/ai/agents"].permission_code == "ai_agent:view"
+    assert by_id["GET:/api/user/me"].scope == "user"
+    assert by_id["POST:/tenant/profiles"].scope == "tenant"
+    assert by_id["POST:/tenant/profiles"].is_write is True
+
+
+def test_catalog_expands_runtime_included_router_nodes() -> None:
+    async def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    _mark_permission(endpoint, "runtime_ops", "view")
+
+    concrete_route = SimpleNamespace(
+        path="/settings",
+        methods={"GET"},
+        endpoint=endpoint,
+        dependant=None,
+        body_field=None,
+        summary="Runtime settings",
+        name="runtime_settings",
+    )
+    included_router = SimpleNamespace(
+        path=None,
+        prefix="/admin",
+        methods=set(),
+        endpoint=None,
+        routes=[
+            SimpleNamespace(
+                path="/runtime",
+                methods=set(),
+                endpoint=None,
+                routes=[concrete_route],
+            )
+        ],
+    )
+    app = SimpleNamespace(routes=[included_router])
+
+    operations = _build_catalog_from_app(app)
+
+    assert [operation.operation_id for operation in operations] == [
+        "GET:/admin/runtime/settings"
+    ]
+    assert operations[0].path == "/admin/runtime/settings"
+    assert operations[0].scope == "admin"
+    assert operations[0].permission_code == "runtime_ops:view"


### PR DESCRIPTION
Fixes #82

## 变更
- 为 internal ops catalog 增加递归路由迭代，兼容 FastAPI/Starlette 运行时保留的 _IncludedRouter / Mount / 嵌套 routes。
- 构建 operation_id 和 scope 时使用展开后的 effective path，保留 /admin、/tenant、/api/user 等父级前缀。
- 新增回归测试覆盖真实 APIRouter.include_router 嵌套和生产形态的运行时 included router 节点。

## 验证
- cd backend && .venv/bin/python -m pytest tests/ai/internal_ops/test_catalog_routes.py -q
- cd backend && .venv/bin/python -m pytest tests/test_internal_ops_builtin_skill.py tests/ai/internal_ops -q
- cd backend && .venv/bin/python -m compileall app/ai/internal_ops/catalog.py tests/ai/internal_ops/test_catalog_routes.py
- cd backend && .venv/bin/python -m ruff check app/ai/internal_ops/catalog.py tests/ai/internal_ops/test_catalog_routes.py
- git diff --check