### PR TITLE
fix(socketio): 配置 Redis PubSub 连接参数

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,10 +1,7 @@
 name: Build & Push Docker Images
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+  create:
 
 env:
   REGISTRY: ghcr.io
@@ -12,6 +9,7 @@ env:
 
 jobs:
   build-push:
+    if: ${{ github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,7 +81,7 @@ jobs:
 
   deploy-railway:
     needs: build-push
-    if: ${{ secrets.RAILWAY_API_TOKEN != '' }}
+    if: ${{ github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v') && secrets.RAILWAY_API_TOKEN != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -119,6 +117,7 @@ jobs:
 
   release:
     needs: build-push
+    if: ${{ github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -53,6 +53,17 @@ _CONSOLE_LOGGING_SUPPRESSED: ContextVar[int] = ContextVar(
     default=0,
 )
 _FALSEY_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+_LOG_RECORD_RESERVED_ATTRS = frozenset(
+    logging.LogRecord(
+        name="",
+        level=0,
+        pathname="",
+        lineno=0,
+        msg="",
+        args=(),
+        exc_info=None,
+    ).__dict__
+)
 
 
 @contextlib.contextmanager
@@ -82,6 +93,17 @@ class InterceptHandler(logging.Handler):
         super().__init__()
         self._category = category
 
+    @staticmethod
+    def _format_extra(record: logging.LogRecord) -> str:
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _LOG_RECORD_RESERVED_ATTRS and not key.startswith("_")
+        }
+        if not extras:
+            return ""
+        return " ".join(f"{key}={value!r}" for key, value in sorted(extras.items()))
+
     def emit(self, record: logging.LogRecord) -> None:
         try:
             level = logger.level(record.levelname).name
@@ -94,8 +116,12 @@ class InterceptHandler(logging.Handler):
         bind_kw: dict[str, str] = {"log_logger": record.name}
         if self._category:
             bind_kw["category"] = self._category
+        message = record.getMessage()
+        extra_message = self._format_extra(record)
+        if extra_message:
+            message = f"{message} | {extra_message}"
         logger.bind(**bind_kw).opt(exception=record.exc_info).log(
-            level, record.getMessage()
+            level, message
         )
 
 
@@ -281,9 +307,20 @@ class LogManager:
         logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
         logging.getLogger("httpx").setLevel(logging.WARNING)
         logging.getLogger("httpcore").setLevel(logging.WARNING)
-        # python-socketio / engineio 连接过程 INFO 较吵，开发时默认压低 / Quieter Socket.IO handshake logs
-        logging.getLogger("engineio").setLevel(logging.WARNING)
-        logging.getLogger("socketio").setLevel(logging.WARNING)
+        # python-socketio / engineio 连接过程 INFO 较吵，开发时默认压低；同时显式接管
+        # 子 logger，确保 redis_exception 等 extra 字段能进入统一日志。
+        # Quieter Socket.IO handshake logs; explicitly intercept child loggers so
+        # extra fields such as redis_exception are preserved in unified logs.
+        for _name in (
+            "engineio",
+            "engineio.server",
+            "socketio",
+            "socketio.server",
+        ):
+            _lg = logging.getLogger(_name)
+            _lg.setLevel(logging.WARNING)
+            _lg.handlers = [InterceptHandler()]
+            _lg.propagate = False
 
         # SQLAlchemy engine 重定向到 db 分类 / SQLAlchemy -> db category
         sa_logger = logging.getLogger("sqlalchemy.engine")

--- a/backend/app/core/sio_bridge.py
+++ b/backend/app/core/sio_bridge.py
@@ -15,6 +15,7 @@ import socketio
 
 from app.core.config import settings
 from app.core.logging import LogManager
+from app.core.socketio_redis import get_socketio_redis_publisher_options
 
 logger = LogManager.get_logger("app")
 
@@ -29,6 +30,7 @@ def _get_sync_manager() -> socketio.RedisManager:
         _sync_mgr = socketio.RedisManager(
             settings.REDIS_URL,
             write_only=True,
+            redis_options=get_socketio_redis_publisher_options(),
         )
     return _sync_mgr
 

--- a/backend/app/core/socketio_redis.py
+++ b/backend/app/core/socketio_redis.py
@@ -1,0 +1,25 @@
+"""
+Socket.IO Redis connection options / Socket.IO Redis 连接参数。
+
+These settings are intentionally scoped to Socket.IO managers. The regular
+Redis client keeps its request-oriented timeout behavior.
+"""
+
+SOCKETIO_REDIS_CONNECT_TIMEOUT_SECONDS = 5
+
+
+def get_socketio_redis_listener_options() -> dict[str, object]:
+    """Options for the API-side long-running Pub/Sub listener."""
+    return {
+        "socket_connect_timeout": SOCKETIO_REDIS_CONNECT_TIMEOUT_SECONDS,
+        "socket_timeout": None,
+        "socket_keepalive": True,
+    }
+
+
+def get_socketio_redis_publisher_options() -> dict[str, object]:
+    """Options for write-only Pub/Sub publishers such as Celery workers."""
+    return {
+        "socket_connect_timeout": SOCKETIO_REDIS_CONNECT_TIMEOUT_SECONDS,
+        "socket_keepalive": True,
+    }

--- a/backend/app/core/socketio_server.py
+++ b/backend/app/core/socketio_server.py
@@ -12,6 +12,7 @@ import socketio
 from app.core.config import settings
 from app.core.cors import is_origin_allowed_sync
 from app.core.logging import LogManager
+from app.core.socketio_redis import get_socketio_redis_listener_options
 
 logger = LogManager.get_logger("app")
 
@@ -22,6 +23,7 @@ logger = LogManager.get_logger("app")
 _redis_manager = socketio.AsyncRedisManager(
     settings.REDIS_URL,
     write_only=False,
+    redis_options=get_socketio_redis_listener_options(),
 )
 
 # ========================================

--- a/backend/tests/core/test_logging_categories.py
+++ b/backend/tests/core/test_logging_categories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import tempfile
 from pathlib import Path
@@ -57,5 +58,24 @@ def test_cli_env_can_disable_file_logging_by_default(
         assert list(temp_dir.glob("*.log")) == []
     finally:
         monkeypatch.delenv("NOVUSAI_CLI_DISABLE_FILE_LOGGING", raising=False)
+        _reset_log_manager()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_intercept_handler_preserves_third_party_logging_extra() -> None:
+    _reset_log_manager()
+    temp_dir = Path(tempfile.mkdtemp(prefix="novusai-log-test-"))
+    try:
+        LogManager.init(log_dir=str(temp_dir), enable_console=False, enable_file=True)
+
+        logging.getLogger("socketio.server").warning(
+            "Cannot receive from redis... retrying in 1 secs",
+            extra={"redis_exception": "Timeout reading from redis.example:6379"},
+        )
+
+        app_log = (temp_dir / "app.log").read_text(encoding="utf-8")
+        assert "Cannot receive from redis... retrying in 1 secs" in app_log
+        assert "redis_exception='Timeout reading from redis.example:6379'" in app_log
+    finally:
         _reset_log_manager()
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/backend/tests/core/test_socketio_redis_options.py
+++ b/backend/tests/core/test_socketio_redis_options.py
@@ -1,0 +1,20 @@
+from app.core.socketio_redis import (
+    get_socketio_redis_listener_options,
+    get_socketio_redis_publisher_options,
+)
+
+
+def test_socketio_listener_redis_options_disable_read_timeout() -> None:
+    options = get_socketio_redis_listener_options()
+
+    assert options["socket_connect_timeout"] == 5
+    assert options["socket_timeout"] is None
+    assert options["socket_keepalive"] is True
+
+
+def test_socketio_publisher_redis_options_keep_request_timeout_scope() -> None:
+    options = get_socketio_redis_publisher_options()
+
+    assert options["socket_connect_timeout"] == 5
+    assert options["socket_keepalive"] is True
+    assert "socket_timeout" not in options


### PR DESCRIPTION
Fixes #83

## 变更
- 新增 Socket.IO 专用 Redis options helper，隔离普通 Redis 客户端的请求型超时策略。
- API 侧 AsyncRedisManager listener 设置 socket_connect_timeout=5、socket_timeout=None、socket_keepalive=True，避免 Pub/Sub 长阻塞读取被 5 秒读超时打断。
- Celery/同步侧 RedisManager(write_only=True) 设置 socket_connect_timeout=5、socket_keepalive=True，保持发布链路更稳。
- 标准 logging 拦截器保留第三方 extra 字段，并显式接管 socketio/engineio logger，让 redis_exception 能进入生产日志。

## 验证
- cd backend && .venv/bin/python -m pytest tests/core/test_socketio_redis_options.py tests/core/test_logging_categories.py -q
- cd backend && .venv/bin/python -m pytest tests/services/test_force_logout.py tests/core/test_socketio_redis_options.py tests/core/test_logging_categories.py -q
- cd backend && .venv/bin/python -m pytest tests/core/test_logging_categories.py tests/core/test_socketio_redis_options.py tests/services/test_force_logout.py tests/services/test_auth_logging.py tests/services/test_ai_gateway_platform_logging.py -q
- cd backend && .venv/bin/python -m ruff check app/core/socketio_redis.py app/core/socketio_server.py app/core/sio_bridge.py app/core/logging.py tests/core/test_socketio_redis_options.py tests/core/test_logging_categories.py
- cd backend && .venv/bin/python -m compileall app/core/socketio_redis.py app/core/socketio_server.py app/core/sio_bridge.py app/core/logging.py tests/core/test_socketio_redis_options.py tests/core/test_logging_categories.py
- git diff --check