### PR TITLE
fix(ci): 增强Railway部署curl调用的错误可观测性

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -111,13 +111,24 @@ jobs:
             exit 0
           fi
           echo "🚀 Triggering Railway redeployment for ${{ matrix.name }} ($SERVICE_ID)"
-          RESPONSE=$(curl -sf -X POST https://api.railway.app/graphql \
+          RAW=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST https://api.railway.app/graphql \
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{
               \"query\": \"mutation { deploymentCreate(input: {serviceId: \\\"$SERVICE_ID\\\"}) { deployment { id status } } }\"
             }")
+          HTTP_STATUS=$(echo "$RAW" | grep "HTTP_STATUS:" | sed 's/.*HTTP_STATUS://')
+          RESPONSE=$(echo "$RAW" | sed '/HTTP_STATUS:/d')
           echo "Response: $RESPONSE"
+          echo "HTTP Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -lt 200 ] || [ "$HTTP_STATUS" -ge 300 ]; then
+            echo "❌ ${{ matrix.name }}: Railway API returned HTTP $HTTP_STATUS"
+            exit 1
+          fi
+          if echo "$RESPONSE" | grep -q '"errors"'; then
+            echo "❌ ${{ matrix.name }}: Railway API returned GraphQL errors"
+            exit 1
+          fi
           echo "✅ ${{ matrix.name }} deployment triggered"
 
   release:


### PR DESCRIPTION
## 背景

CI #25（Docker Images Build and Push）的 4 个 `deploy-railway` job 全部失败，但 `curl -sf` 标志在 HTTP 错误时静默丢弃响应体，导致日志中只能看到 `exit code 22`，无法定位 Railway API 的真实错误原因。

## 变更内容

修改 `.github/workflows/docker-images.yml` 中 `deploy-railway` job 的 curl 调用：

- `curl -sf` → `curl -s -w "\nHTTP_STATUS:%{http_code}"`（移除静默失败标志，附加 HTTP 状态码）
- 分离 `RAW` 为 `RESPONSE`（响应体）和 `HTTP_STATUS`（状态码）
- 打印完整 `Response` 和 `HTTP Status`
- 新增 HTTP 状态码检查（非 2xx → exit 1）
- 新增 GraphQL `"errors"` 字段检查（有错误 → exit 1）

## 效果

下次 Railway 部署失败时，CI 日志将直接显示：
- HTTP 状态码（如 401/403/404/500）
- Railway API 返回的完整错误 message
- GraphQL errors 详情