### PR TITLE
fix(internal-ops): 兼容 FastAPI 0.138 effective route contexts

### DIFF
--- a/backend/app/ai/internal_ops/catalog.py
+++ b/backend/app/ai/internal_ops/catalog.py
@@ -146,6 +146,14 @@ def _iter_routes(routes: Any, prefix: str = ""):
     runtime versions, so catalog building must not rely on a flat app.routes.
     """
     for route in routes or []:
+        effective_route_contexts = getattr(route, "effective_route_contexts", None)
+        if callable(effective_route_contexts):
+            for context in effective_route_contexts():
+                context_path = str(getattr(context, "path", "") or "")
+                if context_path:
+                    yield context, _join_paths(prefix, context_path)
+            continue
+
         route_path = str(getattr(route, "path", "") or "")
         route_prefix = str(getattr(route, "prefix", "") or "")
         nested_routes = getattr(route, "routes", None)

--- a/backend/tests/ai/internal_ops/test_catalog_routes.py
+++ b/backend/tests/ai/internal_ops/test_catalog_routes.py
@@ -94,3 +94,35 @@ def test_catalog_expands_runtime_included_router_nodes() -> None:
     assert operations[0].path == "/admin/runtime/settings"
     assert operations[0].scope == "admin"
     assert operations[0].permission_code == "runtime_ops:view"
+
+
+def test_catalog_expands_fastapi_effective_route_context_nodes() -> None:
+    async def endpoint() -> dict[str, bool]:
+        return {"ok": True}
+
+    _mark_permission(endpoint, "effective_ops", "view")
+
+    context = SimpleNamespace(
+        path="/admin/effective/settings",
+        methods={"GET"},
+        endpoint=endpoint,
+        dependant=None,
+        body_field=None,
+        summary="Effective settings",
+        name="effective_settings",
+    )
+
+    class IncludedRouterNode:
+        def effective_route_contexts(self):
+            return [context]
+
+    app = SimpleNamespace(routes=[IncludedRouterNode()])
+
+    operations = _build_catalog_from_app(app)
+
+    assert [operation.operation_id for operation in operations] == [
+        "GET:/admin/effective/settings"
+    ]
+    assert operations[0].path == "/admin/effective/settings"
+    assert operations[0].scope == "admin"
+    assert operations[0].permission_code == "effective_ops:view"


### PR DESCRIPTION
## 变更

- 让 internal ops catalog 兼容 FastAPI 0.138 的 `_IncludedRouter.effective_route_contexts()` 路由结构。
- 使用 effective route context 自身的 `path / methods / endpoint / dependant / body_field` 构建操作目录，避免只扫描到外层健康检查和静态资源路由。
- 增加回归测试覆盖 FastAPI effective route context 形态。

## 生产排查证据

v0.1.10 镜像内确认：

- `APP_VERSION=0.1.10`
- `fastapi=0.138.0`
- `starlette=1.3.1`
- 当前 `_iter_routes()` 仅展开 8 个外层路由，`catalog=0`
- 通过 `effective_route_contexts()` 可展开 820 条路由，642 条带 `_permission_resource + _permission_action`
- 在容器内 monkey patch 本修复后：

```text
Internal ops catalog built: 563 operations
catalog 563 Counter({'admin': 390, 'tenant': 173})
```

## 验证

```bash
backend/.venv/bin/python -m pytest backend/tests/ai/internal_ops/test_catalog_routes.py -q
backend/.venv/bin/python -m ruff check backend/app/ai/internal_ops/catalog.py backend/tests/ai/internal_ops/test_catalog_routes.py
git diff --check
```

## 后续建议

生产 Docker 构建当前使用 `pip install .`，没有按 `uv.lock` 固定依赖，导致生产依赖漂到本地锁文件之外的新 FastAPI/Starlette 组合。建议后续单独处理镜像依赖锁定，降低类似“本地正常、生产异常”的风险。
