### PR TITLE
fix(docker): 使用 uv.lock 锁定后端镜像依赖

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,19 +17,24 @@ RUN set -eux; \
 
 WORKDIR /app
 
-COPY backend/pyproject.toml backend/README.md ./
+COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /uvx /usr/local/bin/
+
+COPY backend/pyproject.toml backend/uv.lock backend/README.md ./
 COPY VERSION /
 COPY VERSION ./
+RUN uv sync --frozen --no-dev --no-install-project
+
 COPY backend/app ./app
-# 中文: 元数据和源码都进入镜像后再执行一次正式安装，避免 fallback 掩盖构建问题。
-# EN: Install once after metadata and source are present so fallback paths cannot mask build issues.
-RUN pip install --prefix=/install --no-cache-dir .
+# 中文: 生产依赖必须由 uv.lock 决定，避免 pip 按宽松范围解析到未验证的新版本。
+# EN: Production dependencies must come from uv.lock to avoid unverified range resolution.
+RUN uv sync --frozen --no-dev
 
 FROM python:3.12-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
+    PATH="/app/.venv/bin:$PATH" \
     TZ=Asia/Shanghai
 
 RUN set -eux; \
@@ -46,7 +51,7 @@ RUN set -eux; \
 
 WORKDIR /app
 
-COPY --from=builder /install /usr/local
+COPY --from=builder --chown=novusai:novusai /app/.venv /app/.venv
 COPY --from=builder /VERSION /VERSION
 COPY --from=builder --chown=novusai:novusai /app/VERSION /app/VERSION
 COPY --chown=novusai:novusai backend/ .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -120,6 +120,8 @@ services:
         VITE_APP_TITLE: "NovusAI SaaS Dev"
         VITE_APP_NAMESPACE: novusai-web-saas
         VITE_APP_STORE_SECURE_KEY: novusai-dev-key-2024
+    environment:
+      VITE_GLOB_API_URL: http://localhost:8000
     depends_on:
       backend-api:
         condition: service_started


### PR DESCRIPTION
## 变更

- 后端 Docker 镜像构建改用 `uv sync --frozen --no-dev`，依赖版本由 `backend/uv.lock` 锁定。
- runtime 阶段复制 builder 生成的 `/app/.venv`，并通过 `PATH=/app/.venv/bin:$PATH` 使用锁定后的 CLI/依赖。
- `docker-compose.dev.yml` 为 `frontend` 补充运行时 `VITE_GLOB_API_URL=http://localhost:8000`，避免容器启动时 `_app.config.js` 回落到 `https://api.novusai.example.com`。

## 背景

v0.1.10 生产镜像使用 `pip install .` 按宽松依赖范围解析，导致容器装到 `fastapi=0.138.0 / starlette=1.3.1`，与本地锁文件依赖组合不一致。此次改动让生产/开发镜像依赖与 `uv.lock` 保持一致，降低“本地正常、生产异常”的依赖漂移风险。

## 验证

- `git diff --check`
- `docker compose -f docker-compose.dev.yml config --services`
- 本地 Docker Compose 启动成功
- 本地 Docker 环境智能体工具调用测试成功

## 说明

本 PR 不包含 internal ops catalog 的 FastAPI 0.138 兼容修复；该修复在独立 PR #89 中处理。
