### PR TITLE
fix(engine): 修复非流式 ReAct 轮次参数透传

### DIFF
--- a/backend/app/ai/engine/conversation_sync_io_adapter.py
+++ b/backend/app/ai/engine/conversation_sync_io_adapter.py
@@ -35,6 +35,9 @@ class _SyncIOAdapter:
         tool_use_policy: ToolUsePolicy,
         **kwargs: Any,
     ) -> ModelRoundResult:
+        # Streaming adapters use this for turn-flow projection; the sync engine
+        # call does not accept it.
+        kwargs.pop("react_round_index", None)
         runtime_call_overrides = build_model_request_overrides(
             execution_path=getattr(self.prep, "execution_path", None),
             tools=tools,

--- a/backend/app/ai/engine/conversation_sync_io_support.py
+++ b/backend/app/ai/engine/conversation_sync_io_support.py
@@ -43,6 +43,9 @@ async def call_sync_llm(
     context_sources: list[Any],
     **kwargs: Any,
 ) -> ModelRoundResult:
+    # Runtime-only metadata consumed by stream adapters must not leak into the
+    # non-streaming ConversationEngine._call_llm signature.
+    kwargs.pop("react_round_index", None)
     runtime_call_overrides = build_model_request_overrides(
         execution_path=getattr(prep, "execution_path", None),
         tools=tools,

--- a/backend/tests/services/test_conversation_engine_prepare_execution.py
+++ b/backend/tests/services/test_conversation_engine_prepare_execution.py
@@ -1122,6 +1122,50 @@ async def test_sync_io_adapter_fast_text_round_passes_low_reasoning_override() -
 
 
 @pytest.mark.asyncio
+async def test_sync_io_adapter_consumes_react_round_index_before_llm_call() -> None:
+    engine = ConversationEngine(
+        db=MagicMock(), gateway=MagicMock(), sandbox=MagicMock()
+    )
+    engine._call_llm = AsyncMock(
+        return_value=ChatResponse(
+            message=ChatMessage(role="assistant", content="ok"),
+            total_tokens=3,
+        )
+    )
+    request = ExecutionRequest(
+        agent_id=1,
+        tenant_id=1,
+        user_id=1,
+        user_role="tenant_admin",
+        billing_context={},
+        messages=[ChatMessage(role="user", content="你好")],
+    )
+    sync_adapter = _SyncIOAdapter(
+        engine=engine,
+        agent=_build_agent(),
+        request=request,
+        prep=SimpleNamespace(
+            all_tools=[],
+            route_result=None,
+            execution_path="normal",
+        ),
+        selected_skill_names=[],
+        context_sources=[],
+        runtime_contract=build_stream_runtime_contract(engine),
+    )
+
+    await sync_adapter.call_llm(
+        messages=[ChatMessage(role="user", content="你好")],
+        tools=[],
+        tool_use_policy=ToolUsePolicy(),
+        react_round_index=0,
+    )
+
+    assert engine._call_llm.await_count == 1
+    assert "react_round_index" not in engine._call_llm.await_args.kwargs
+
+
+@pytest.mark.asyncio
 async def test_prepare_execution_exposes_plugin_weather_tools_by_metadata_only() -> (
     None
 ):


### PR DESCRIPTION
## 变更说明

- 在非流式同步 IO 适配器中消费 `react_round_index`，避免将运行时元数据透传给不接受该参数的 `ConversationEngine._call_llm()`
- 在同步调用辅助函数中增加防御性处理，统一非流式调用边界
- 新增回归测试，验证 ReAct 轮次索引不会泄漏到模型调用参数

## 测试

- `uv run pytest tests/services/test_conversation_engine_prepare_execution.py::test_sync_io_adapter_consumes_react_round_index_before_llm_call -q`（1 passed）
- `uv run pytest tests/services/test_conversation_engine_prepare_execution.py -k sync_io_adapter -q`（2 passed）
- `uv run pytest tests/ai/engine/test_turn_executor.py -q`（11 passed）
- `uv run ruff check app/ai/engine/conversation_sync_io_adapter.py app/ai/engine/conversation_sync_io_support.py tests/services/test_conversation_engine_prepare_execution.py`
- `git diff --check`

## 风险

变更仅过滤非流式链路不支持的运行时元数据；流式适配器仍保留并使用 `react_round_index`，不影响现有轮次投影逻辑。

Fixes #103